### PR TITLE
mmu_ace: show Unload button whenever a gate is physically loaded

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -1161,13 +1161,14 @@ class MmuAceController:
         gate_speed_override = [gate.speed_override if gate.speed_override >= 0 else 100 for gate in gates]
         gate_vendor = [gate.vendor if hasattr(gate, 'vendor') and gate.vendor else "" for gate in gates]
 
-        # Determine filament_pos based on loaded_gate vs selected gate
-        # This controls Load/Unload button visibility in Happy Hare GUI
-        if self.ace.loaded_gate != TOOL_GATE_UNKNOWN and self.ace.loaded_gate == self.ace.gate:
-            # Currently selected gate is the one that's loaded -> show LOADED (Unload button)
+        # Determine filament_pos based on whether anything is physically loaded.
+        # This controls Load/Unload button visibility in Happy Hare GUI.
+        # We do NOT require the selected gate to match loaded_gate: the user may have
+        # selected a different gate while gate N is still threaded, and the Unload button
+        # must still appear so they can retract the loaded filament.
+        if self.ace.loaded_gate != TOOL_GATE_UNKNOWN:
             filament_pos = FILAMENT_POS_LOADED
         else:
-            # Either no gate loaded, or different gate selected -> show UNLOADED (Load button)
             filament_pos = FILAMENT_POS_UNLOADED
 
         filament_name = "Unknown"


### PR DESCRIPTION
## Summary

- `filament_pos` was computed as `LOADED` only when `loaded_gate` matched the currently selected gate. If the user selected a different gate while filament was still threaded (a common situation since the UI defaults to whichever gate was last interacted with), `loaded_gate != gate` caused `filament_pos` to report `UNLOADED` and hid the Unload button entirely.
- Fix: `filament_pos` is now set to `LOADED` whenever `loaded_gate != TOOL_GATE_UNKNOWN`, regardless of which gate is selected in the UI. `MMU_UNLOAD` with no `GATE` parameter already calls `UNWIND_ALL_FILAMENT`, so the action is safe in all selection states.
- Tested live on Kobra S1 with ACE Hub: Unload button now appears correctly when filament is threaded.

Closes #9 (also see the related fingerprint fix in 3d02113).

## Test plan

- [ ] Load filament into any gate via the ACE
- [ ] Select a different gate in the MMU panel
- [ ] Confirm Unload button is visible
- [ ] Click Unload and confirm filament retracts correctly
- [ ] Confirm Load button appears after unload completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)