### PR TITLE
KS1M support fix

### DIFF
--- a/files/3-rinkhals/opt/rinkhals/scripts/process-cfg.py
+++ b/files/3-rinkhals/opt/rinkhals/scripts/process-cfg.py
@@ -19,7 +19,8 @@ def readSections(path, hintPath = None):
     with open(path, 'r') as f:
         config = f.read()
 
-    sections = re.findall("(?:^|\n)\[([^\]]+)\]((?:.|\n)*?)(?=\n\[|$)", config)
+    # Accept section headers with optional indentation before '['.
+    sections = re.findall(r"(?:^|\n)\s*\[([^\]]+)\]((?:.|\n)*?)(?=\n\s*\[|$)", config)
 
     i = 0
     while i < len(sections):
@@ -46,7 +47,7 @@ def main():
             sections.append(section)
 
     # Decode sections content
-    sections = [ ( s[0], re.findall('(?:^|\n)([^\[\]\s:]+[^\[\]:]+):((?:.|\n)*?)(?=\n[^\[\]\s#:]|\n\[|$)', s[1]) ) for s in sections ]
+    sections = [ ( s[0], re.findall(r'(?:^|\n)([^\[\]\s:]+[^\[\]:]+):((?:.|\n)*?)(?=\n[^\[\]\s#:]|\n\[|$)', s[1]) ) for s in sections ]
 
     # Resolve section overrides
     resolvedSections = {}

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -1283,7 +1283,6 @@ class Kobra:
                     logging.info('[Kobra] Injected objects list')
                     
                     objects = [
-                        "motion_report",
                         "gcode_macro t0",
                         "gcode_macro t1",
                         "gcode_macro t2",
@@ -1292,7 +1291,7 @@ class Kobra:
                         "heaters",
                         "respond",
                         "display_status",
-                            "exclude_object",
+                        "exclude_object",
                         "extruder",
                         "fan",
                         "gcode_move",
@@ -1313,6 +1312,12 @@ class Kobra:
                         "bed_mesh \"default\"",
                         "idle_timeout"
                     ]
+
+                    # For KS1M: Do not expose motion_report to avoid GoKlipper panic:
+                    # "interface conversion: interface {} is chelper._Ctype_struct_pull_move, not *chelper._Ctype_struct_pull_movegoroutine"
+                    # For other models, insert motion_report at same position as before to avoid any regression
+                    if self.KOBRA_MODEL_CODE != 'KS1M':
+                        objects.insert(0, "motion_report")
                     
                     web_request.endpoint = 'gcode/help'
                     result = await original_request(me, web_request)


### PR DESCRIPTION
- Fixed config parser to accept section headers with optional indentation before '['.
- Workaround: Do not expose motion_report to avoid GoKlipper panic on KS1M at homing