### PR TITLE
Fix unbound filename in patch_mqtt_print

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -1055,9 +1055,9 @@ class Kobra:
     def patch_mqtt_print(self):
         async def handle_gcode_print_file(args: dict, delegate_run_gcode):
             logging.info(f'[Kobra] Print file: {args}')
+            filename = args["FILENAME"] if "FILENAME" in args else None
             if self.is_goklipper_running():
                 self._total_layer = 0
-                filename = args["FILENAME"] if "FILENAME" in args else None
                 logging.info(f'[Kobra] Print file: {filename}')
                 
                 if filename and self.is_using_mqtt():


### PR DESCRIPTION
In function def patch_mqtt_print() filename is only assigned inside the if self.is_goklipper_running(): block, but referenced later. When is_goklipper_running() is False, filename is never defined.

But when Vanilla-Klipper App is used, is_goklipper_running() will be false and filename is never defined and crashes later when getting logged.