### PR TITLE
mmu_ace: auto-feed filament at print start (#464)

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -244,6 +244,19 @@ TOOL_GATE_BYPASS = -2
 # Maximum tools for memory management (prevents unbounded list growth)
 MAX_TOOLS = 32  # Reasonable limit for multi-material printing
 
+# ACE auto-feed defaults (issue #464). Tuned for the ACE Pro tube length on
+# Kobra 3 Combo; ACE v1 and other K-series tube lengths may need different
+# values. Promote to moonraker config once we have more hardware data points.
+ACE_AUTO_FEED_LENGTH_MM = 80
+ACE_AUTO_FEED_SPEED_MM_S = 25
+
+# print_stats.state values that mean "this print isn't going to happen". The
+# auto-feed poller treats any of these as a signal to abandon waiting rather
+# than burn through its full heat-up timeout after a user cancel or error.
+ACE_AUTO_FEED_DEAD_PRINT_STATES = frozenset({
+    "cancelled", "complete", "error", "standby"
+})
+
 FILAMENT_POS_UNKNOWN = -1
 FILAMENT_POS_UNLOADED = 0 # Parked in gate
 FILAMENT_POS_HOMED_GATE = 1 # Homed at either gate or gear sensor (currently assumed mutually exclusive sensors)
@@ -541,6 +554,10 @@ class MmuAceController:
         self.eventloop = self.server.get_event_loop()
         self._last_status_update = 0.0
         self._status_update_task: Optional[asyncio.Task] = None
+        # Tracks the single in-flight _plan_load_ace retry loop. set_ace() can be
+        # re-entered (via reinit()); without tracking, overlapping retry loops
+        # would both poll query_objects for up to ~20s.
+        self._plan_load_task: Optional[asyncio.Task] = None
         self._status_update_delay = 0.2  # 200ms debounce for rapid commands
         self._throttle_delay = 0.3  # 300ms minimum delay between updates (max 3/sec)
         self._pending_update = False  # Flag to track if update is needed
@@ -772,7 +789,12 @@ class MmuAceController:
         self.ace = ace
         self._handle_status_update(force=True)
 
-        self.eventloop.create_task(self._plan_load_ace())
+        # Cancel a retry loop left over from an earlier set_ace()/reinit() call
+        # so only one _plan_load_ace can poll at a time.
+        if self._plan_load_task is not None and not self._plan_load_task.done():
+            logging.info("set_ace: cancelling stale _plan_load_ace task")
+            self._plan_load_task.cancel()
+        self._plan_load_task = self.eventloop.create_task(self._plan_load_ace())
 
     async def _plan_load_ace(self, retry=10, delay=2):
         for _ in range(retry):
@@ -1451,6 +1473,13 @@ class MmuAcePatcher:
         host = config.get("host", None)
         self.ace_controller = MmuAceController(self.server, host)
 
+        # Tracks the single in-flight auto-feed poller (issue #464). patch_print_data
+        # runs inside kobra.py's network retry loop, so without tracking, a retried
+        # print start would spawn duplicate pollers that all fire FEED_FILAMENT.
+        # Initialised before reinit() so the cancel-on-reinit guard can read it
+        # safely on the first call (reinit() runs during __init__).
+        self._auto_feed_task = None
+
         self.reinit()
 
         # mmu test enpoints
@@ -1486,6 +1515,20 @@ class MmuAcePatcher:
         self.kobra.register_status_patcher(self.patch_status)
 
         self.kobra.register_print_data_patcher(self.patch_print_data)
+
+        # Tube-length / push-speed for the auto-feed FEED_FILAMENT command.
+        # Defaults are tuned for ACE Pro on Kobra 3 Combo; ACE v1 and other
+        # K-series tube lengths can override in moonraker.conf under [mmu_ace]:
+        #   auto_feed_length: 80      ; mm
+        #   auto_feed_speed:  25      ; mm/s
+        # `above=0` makes moonraker reject zero / negative / non-numeric values
+        # at startup instead of silently feeding zero mm at print start.
+        self._auto_feed_length = config.getfloat(
+            "auto_feed_length", ACE_AUTO_FEED_LENGTH_MM, above=0
+        )
+        self._auto_feed_speed = config.getfloat(
+            "auto_feed_speed", ACE_AUTO_FEED_SPEED_MM_S, above=0
+        )
 
         # Add AnycubicSlicerNext to supported slicers
         self.setup_anycubic_slicer()
@@ -2207,6 +2250,16 @@ class MmuAcePatcher:
 
     def reinit(self):
 
+        # Cancel any in-flight auto-feed poller before swapping self.ace --
+        # otherwise an old task would keep polling against the fresh MmuAce
+        # and could fire FEED_FILAMENT after the state reset. Symmetric to
+        # the cancel-on-retry guard inside patch_print_data; same risk shape,
+        # just at the reinit boundary instead of the network-retry boundary.
+        if self._auto_feed_task is not None and not self._auto_feed_task.done():
+            logging.info("reinit: cancelling stale auto-feed task")
+            self._auto_feed_task.cancel()
+            self._auto_feed_task = None
+
         self.ace = MmuAce()
         self.ace_controller.set_ace(self.ace)
 
@@ -2387,7 +2440,165 @@ class MmuAcePatcher:
 
             logging.debug(f"mmu_ace: patch_print_data: {json.dumps(print_data)}")
 
+            # Auto-feed filament when the ACE has no slot loaded into the toolhead
+            # going into this print. Without this, prints fail to extrude after the
+            # ACE retracts filament between prints (the touchscreen Color Match →
+            # Print flow currently doesn't issue FEED_FILAMENT; this hook fills
+            # that gap). See issue #464.
+            #
+            # Slot selection order:
+            #   1. self.ace.gate if set — honours touchscreen Color Match selection
+            #      (relies on #443 being fixed; safe fallback if not)
+            #   2. mapping[0].ams_index — the first slot mapped from the slicer's
+            #      tool order. Correct for single-colour prints and for the initial
+            #      feed of multi-colour prints (subsequent T-commands switch).
+            if self.ace.loaded_gate == TOOL_GATE_UNKNOWN and mapping:
+                if self.ace.gate != TOOL_GATE_UNKNOWN:
+                    candidate = self.ace.gate
+                    source = "Color Match (self.ace.gate)"
+                else:
+                    candidate = mapping[0]["ams_index"]
+                    source = "ams_box_mapping[0]"
+
+                # Reject a target gate the printer doesn't have. A stale Color
+                # Match value or a slicer emitting a slot index higher than the
+                # configured ACE gate count would otherwise resolve to an
+                # ID/INDEX pair pointing at a non-existent ACE, and the
+                # resulting FEED_FILAMENT response from gklib is undefined.
+                num_gates = sum(len(unit.gates) for unit in self.ace.units)
+                if not isinstance(candidate, int) or not 0 <= candidate < num_gates:
+                    logging.warning(
+                        f"patch_print_data: target gate {candidate!r} (via {source}) "
+                        f"out of range for {num_gates}-gate setup; skipping auto-feed"
+                    )
+                else:
+                    target_gate = candidate
+                    logging.info(
+                        f"patch_print_data: no filament currently loaded, "
+                        f"scheduling auto-feed for gate {target_gate} (via {source})"
+                    )
+                    # Cancel a poller left over from an earlier print-start attempt
+                    # (patch_print_data is re-entered on each kobra.py network retry)
+                    # so only one auto-feed can ever fire for this print.
+                    if self._auto_feed_task is not None and not self._auto_feed_task.done():
+                        logging.info("patch_print_data: cancelling stale auto-feed task")
+                        self._auto_feed_task.cancel()
+                    self._auto_feed_task = self.ace_controller.eventloop.create_task(
+                        self._auto_feed_at_print_start(target_gate)
+                    )
+
         return print_data
+
+    async def _auto_feed_at_print_start(self, gate: int) -> None:
+        """Auto-feed filament from `gate` shortly after a print starts.
+
+        Workaround for issue #464: the Color Match → Print flow doesn't issue
+        FEED_FILAMENT, so a print after the ACE has retracted filament starts
+        with an empty nozzle and fails to extrude.
+
+        Waits until the extruder has been commanded to a real print temperature
+        (target >= 190 C) and is within 10 C of target. This avoids triggering
+        during the LeviQ3 probing routine, which oscillates target between
+        170 C (extru_temp) and 140 C (extru_end_temp) -- feeding during that
+        window would either be rejected by min_extrude_temp or ooze onto the
+        probing nozzle.
+
+        Aborts early if the print enters a terminal state (cancelled / error /
+        complete / standby) so a user-cancelled print doesn't leave the poller
+        spinning for the full MAX_WAIT_SECONDS. Cancellation by the
+        patch_print_data retry-tracker raises asyncio.CancelledError, which is
+        caught at the outer scope so the task ends with a clear log line
+        rather than the asyncio default "Task was destroyed" warning.
+        """
+        FEED_TARGET_MIN = 190
+        FEED_TEMP_MARGIN = 10
+        MAX_WAIT_SECONDS = 600
+        POLL_INTERVAL = 2.0
+
+        try:
+            start = time.time()
+            while time.time() - start < MAX_WAIT_SECONDS:
+                try:
+                    # Bail if loaded externally (e.g. via MMU_LOAD or T-command)
+                    if self.ace.loaded_gate != TOOL_GATE_UNKNOWN:
+                        logging.info(
+                            f"auto-feed: gate {self.ace.loaded_gate} loaded externally, "
+                            f"skipping scheduled auto-feed"
+                        )
+                        return
+
+                    result = await self.ace_controller.printer.query_objects({
+                        "extruder": ["temperature", "target"],
+                        "print_stats": ["state"],
+                    })
+                    if not isinstance(result, dict):
+                        result = {}
+
+                    # Bail if the print is no longer running. Covers user
+                    # cancel, gklib error, completion, and unexpected fall back
+                    # to standby before heat-up — without this the poller
+                    # would keep waiting up to MAX_WAIT_SECONDS after a cancel.
+                    print_stats = result.get("print_stats") or {}
+                    state = str(print_stats.get("state", "") or "").lower()
+                    if state in ACE_AUTO_FEED_DEAD_PRINT_STATES:
+                        logging.info(
+                            f"auto-feed: print state is '{state}', "
+                            f"abandoning auto-feed for gate {gate}"
+                        )
+                        return
+
+                    ext = result.get("extruder") or {}
+                    temp = float(ext.get("temperature", 0) or 0)
+                    target = float(ext.get("target", 0) or 0)
+
+                    if target >= FEED_TARGET_MIN and temp >= (target - FEED_TEMP_MARGIN):
+                        ace_id = gate // 4
+                        local_index = gate % 4
+                        gcode = (
+                            f"FEED_FILAMENT ID={ace_id} INDEX={local_index} "
+                            f"LENGTH={self._auto_feed_length} "
+                            f"SPEED={self._auto_feed_speed}"
+                        )
+                        logging.info(f"auto-feed: sending {gcode}")
+                        await self.ace_controller.printer.send_gcode(gcode)
+
+                        self._commit_loaded_gate(gate)
+                        return
+
+                except asyncio.CancelledError:
+                    # Never swallow cancellation via the broad Exception
+                    # catch below — propagate to the outer handler so the
+                    # task ends promptly and is logged.
+                    raise
+                except Exception as exc:
+                    logging.warning(f"auto-feed: poll error: {exc}")
+
+                await asyncio.sleep(POLL_INTERVAL)
+
+            logging.warning(
+                f"auto-feed: gave up after {MAX_WAIT_SECONDS}s "
+                f"(extruder target never reached {FEED_TARGET_MIN} C)"
+            )
+        except asyncio.CancelledError:
+            # patch_print_data cancels stale pollers before spawning new
+            # ones; shutdown lands here too. No cleanup needed: the loaded
+            # state is only mutated by _commit_loaded_gate on the success
+            # path, so cancellation can never leave split state behind.
+            logging.info(f"auto-feed: cancelled before completing (gate {gate})")
+            raise
+
+    def _commit_loaded_gate(self, gate: int) -> None:
+        """Atomically mark `gate` as the gate now loaded into the toolhead.
+
+        Single-threaded asyncio guarantees no concurrent reader can see
+        split state across these three assignments — but ONLY if no
+        `await` is introduced between them. Keep the writes here, in a
+        sync helper, so the invariant is visible and a future change
+        cannot accidentally interleave an await between the fields.
+        """
+        self.ace.gate = gate
+        self.ace.tool = gate
+        self.ace.loaded_gate = gate
 
     def _combine(self, sourceA, sourceB):
         result = {}


### PR DESCRIPTION
## Summary

Fixes issue #464 — Color Match → Print flow on Kobra 3 Combo never issues `FEED_FILAMENT`, so the first print after the ACE retracts filament starts with an empty nozzle and lays down nothing.

`patch_print_data` schedules a background poller (`_auto_feed_at_print_start`) that waits for hotend target ≥ 190 °C and within 10 °C of target — dodging the LeviQ3 probing window — then issues `FEED_FILAMENT` for the slot the user picked.

## What's in the change

- **Slot selection** prefers `self.ace.gate` (touchscreen Color Match) when set, falling back to `mapping[0]["ams_index"]` (slicer's first tool order) when Color Match state hasn't propagated (Rinkhals #443). Bounds-checked against `sum(len(u.gates) for u in self.ace.units)` — out-of-range candidates skip the schedule with a warning rather than firing at a non-existent ACE.
- **Task lifecycle** is fully managed:
  - `_auto_feed_task` / `_plan_load_task` hold single in-flight references; any stale task is cancelled before a new one is spawned (protects `kobra.py` network-retry and `reinit()` boundaries alike).
  - `_auto_feed_at_print_start` wraps in `try/except asyncio.CancelledError` for clean logged cancellation; inner `except asyncio.CancelledError: raise` so the broad `except Exception` can't swallow it.
  - Three-field loaded-gate commit (`gate / tool / loaded_gate`) factored to `_commit_loaded_gate()` with the "no `await` between these writes" invariant called out in a comment.
- **Bail-out on dead print state** — the poll loop queries `print_stats.state` alongside the extruder and abandons the wait when state lands in `{cancelled, complete, error, standby}`, instead of waiting up to `MAX_WAIT_SECONDS` (600 s) after a cancel or error.
- **Configurable push length / speed** via `[mmu_ace]` in `moonraker.conf`:
  ```ini
  [mmu_ace]
  auto_feed_length: 80    ; mm  -- ACE Pro default
  auto_feed_speed:  25    ; mm/s
  ```
  Both default to module-level constants; `config.getfloat(..., above=0)` rejects zero / negative / non-numeric values at moonraker startup. Lets ACE v1 / other K-series tube lengths override per printer without source edits.

## Files changed

- `files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py`

## Test plan

- [x] `tests/test_mmu_ace.py` — 8 tests pass (`python3 -m unittest test_mmu_ace`).
- [ ] **Live tests on Kobra 3 Combo (Rinkhals 20260501_01) — running 2026-05-27:**
  - Cancel a print during heat-up → expect `auto-feed: print state is 'cancelled', abandoning auto-feed` within one poll interval, not a 600 s timeout.
  - Force a retry storm at print start → expect one `cancelling stale auto-feed task` + one `cancelled before completing` log pair, no duplicate `FEED_FILAMENT`.
  - Set `auto_feed_length: 100` in `[mmu_ace]`, reboot, start a print → expect emitted `FEED_FILAMENT ... LENGTH=100 ...`.
  - Default config, normal print → expect auto-feed at the correct slot.

Closes #464.

---

Continuation of jbatonnet/Rinkhals#465 — moved to this repo on @martinbogo's request, retargeted at `develop`, and squashed to a single commit for review clarity.
