### PR TITLE
Fix K3SysUi spawning udhcpc after dhcp app started

### DIFF
--- a/files/3-rinkhals/tools.sh
+++ b/files/3-rinkhals/tools.sh
@@ -39,10 +39,11 @@ beep() {
     echo 0 > /sys/class/pwm/pwmchip0/pwm0/enable
 }
 log() {
-    echo "${*}"
+    TS=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$TS]: ${*}"
 
     mkdir -p $RINKHALS_LOGS
-    echo "$(date): ${*}" >> $RINKHALS_LOGS/rinkhals.log
+    echo "[$TS]: ${*}" >> $RINKHALS_LOGS/rinkhals.log
 }
 quit() {
     exit 1

--- a/files/4-apps/home/rinkhals/apps/10-hostname-dns/app.sh
+++ b/files/4-apps/home/rinkhals/apps/10-hostname-dns/app.sh
@@ -1,6 +1,7 @@
+# shellcheck source=../../../../../3-rinkhals/tools.sh
 source /useremain/rinkhals/.current/tools.sh
 
-APP_ROOT=$(dirname $(realpath $0))
+APP_ROOT=$(dirname "$(realpath "$0")")
 APP_NAME="10-hostname-dns"
 
 resolve_hostname() {
@@ -22,6 +23,7 @@ resolve_hostname() {
     fi
 
     # Sanitize: lowercase, replace invalid chars with hyphens, trim leading/trailing hyphens
+    # shellcheck disable=SC2019,SC2018 # (use only latin chars, others will be replaced with hyphens)
     HOSTNAME=$(echo "$HOSTNAME" | tr 'A-Z' 'a-z' | sed 's/[^a-z0-9-]/-/g; s/^-*//; s/-*$//' | head -c 63)
 
     # Final guard: if sanitization produced an empty string, use a fallback
@@ -33,7 +35,7 @@ resolve_hostname() {
 }
 
 status() {
-    PIDS=$(get_by_name mdns_responder.py)
+    PIDS=$(get_by_name mdns_responder.py; get_by_name dhcp_watchdog.sh)
 
     if [ "$PIDS" = "" ]; then
         report_status $APP_STATUS_STOPPED
@@ -55,28 +57,28 @@ start() {
         log "/!\ Failed to set hostname to $HOSTNAME"
     fi
 
-    # Propagate hostname via DHCP if enabled
+    # Propagate hostname via DHCP if enabled.
+    # K3SysUi may (re)spawn udhcpc without the hostname flag at any time,
+    # so we run a watchdog that replaces rogue instances.
     DHCP_ENABLED=$(get_app_property $APP_NAME dhcp_hostname)
     if [ "$DHCP_ENABLED" = "True" ]; then
-        # Restart each udhcpc instance with -H so the router registers the hostname
-        for UDHCPC_PID in $(get_by_name udhcpc); do
-            UDHCPC_IFACE=$(cat /proc/$UDHCPC_PID/cmdline 2>/dev/null | tr '\0' '\n' | grep -A1 -- '^-i$' | tail -1)
-            if [ -n "$UDHCPC_IFACE" ]; then
-                kill $UDHCPC_PID
-                udhcpc -i "$UDHCPC_IFACE" -H "$HOSTNAME" -b &
-            fi
-        done
-
+        cd "$APP_ROOT" || exit 1
+        sh dhcp_watchdog.sh "$HOSTNAME" >> $RINKHALS_LOGS/app-hostname-dns-dhcp.log 2>&1 &
+        log "Started udhcpc watchdog to propagate hostname via DHCP"
     fi
 
     # Start mDNS responder
     mkdir -p $RINKHALS_LOGS
-    cd $APP_ROOT
-    python3 mdns_responder.py "$HOSTNAME" >> $RINKHALS_LOGS/app-hostname-dns.log 2>&1 &
+    cd "$APP_ROOT" || exit 1
+    python3 mdns_responder.py "$HOSTNAME" >> $RINKHALS_LOGS/app-hostname-dns-mdns.log 2>&1 &
+    log "Started mDNS responder to propagate hostname via mDNS"
 }
 
 stop() {
     kill_by_name mdns_responder.py
+    log "Stopped mDNS responder"
+    kill_by_name dhcp_watchdog.sh
+    log "Stopped udhcpc watchdog"
 }
 
 case "$1" in

--- a/files/4-apps/home/rinkhals/apps/10-hostname-dns/app.sh
+++ b/files/4-apps/home/rinkhals/apps/10-hostname-dns/app.sh
@@ -35,7 +35,7 @@ resolve_hostname() {
 }
 
 status() {
-    PIDS=$(get_by_name mdns_responder.py; get_by_name dhcp_watchdog.sh)
+    PIDS="$(get_by_name mdns_responder.py) $(get_by_name dhcp_watchdog.sh)"
 
     if [ "$PIDS" = "" ]; then
         report_status $APP_STATUS_STOPPED

--- a/files/4-apps/home/rinkhals/apps/10-hostname-dns/dhcp_watchdog.sh
+++ b/files/4-apps/home/rinkhals/apps/10-hostname-dns/dhcp_watchdog.sh
@@ -1,0 +1,48 @@
+# Watchdog that ensures all udhcpc instances have the hostname flag set.
+# K3SysUi may (re)spawn udhcpc without -x hostname: at any time,
+# so this script periodically checks and replaces rogue instances.
+
+# shellcheck source=../../../../../3-rinkhals/tools.sh
+source /useremain/rinkhals/.current/tools.sh
+
+HOSTNAME="$1"
+CHECK_INTERVAL=30
+
+if [ -z "$HOSTNAME" ]; then
+    log "dhcp_watchdog: no hostname provided"
+    exit 1
+fi
+
+log "dhcp_watchdog: started, monitoring for hostname '$HOSTNAME'"
+
+while true; do
+    sleep $CHECK_INTERVAL
+
+    REPLACED_IFACES=""
+    for UDHCPC_PID in $(get_by_name udhcpc); do
+        CMDLINE=$(cat "/proc/$UDHCPC_PID/cmdline" 2>/dev/null | tr '\0' ' ')
+
+        # Skip instances that already have the hostname flag
+        if echo "$CMDLINE" | grep -q -- "-x hostname:$HOSTNAME"; then
+            continue
+        fi
+
+        # Extract interface from this rogue instance
+        IFACE=$(cat "/proc/$UDHCPC_PID/cmdline" 2>/dev/null | tr '\0' '\n' | grep -A1 -- '^-i$' | tail -1)
+        if [ -z "$IFACE" ]; then
+            continue
+        fi
+
+        log "dhcp_watchdog: killing rogue udhcpc PID $UDHCPC_PID on $IFACE"
+        kill "$UDHCPC_PID"
+
+        # Only spawn one replacement per interface per cycle
+        if ! echo "$REPLACED_IFACES" | grep -q "$IFACE"; then
+            log "dhcp_watchdog: starting udhcpc on $IFACE with hostname $HOSTNAME"
+            # Use -b -i order to match K3SysUi's expected format,
+            # so it can manage the lifecycle on WiFi reconnects
+            udhcpc -b -i "$IFACE" -x hostname:"$HOSTNAME" &
+            REPLACED_IFACES="$REPLACED_IFACES $IFACE"
+        fi
+    done
+done

--- a/files/4-apps/home/rinkhals/apps/10-hostname-dns/dhcp_watchdog.sh
+++ b/files/4-apps/home/rinkhals/apps/10-hostname-dns/dhcp_watchdog.sh
@@ -23,9 +23,9 @@ while true; do
         CMDLINE=$(cat "/proc/$UDHCPC_PID/cmdline" 2>/dev/null | tr '\0' ' ')
 
         # Skip instances that already have the hostname flag
-        if echo "$CMDLINE" | grep -q -- "-x hostname:$HOSTNAME"; then
-            continue
-        fi
+        case "$CMDLINE" in
+            *"-x hostname:$HOSTNAME"*) continue ;;
+        esac
 
         # Extract interface from this rogue instance
         IFACE=$(cat "/proc/$UDHCPC_PID/cmdline" 2>/dev/null | tr '\0' '\n' | grep -A1 -- '^-i$' | tail -1)
@@ -37,12 +37,16 @@ while true; do
         kill "$UDHCPC_PID"
 
         # Only spawn one replacement per interface per cycle
-        if ! echo "$REPLACED_IFACES" | grep -q "$IFACE"; then
-            log "dhcp_watchdog: starting udhcpc on $IFACE with hostname $HOSTNAME"
-            # Use -b -i order to match K3SysUi's expected format,
-            # so it can manage the lifecycle on WiFi reconnects
-            udhcpc -b -i "$IFACE" -x hostname:"$HOSTNAME" &
-            REPLACED_IFACES="$REPLACED_IFACES $IFACE"
-        fi
+        case " $REPLACED_IFACES " in
+            *" $IFACE "*)
+                ;;
+            *)
+                log "dhcp_watchdog: starting udhcpc on $IFACE with hostname $HOSTNAME"
+                # Use -b -i order to match K3SysUi's expected format,
+                # so it can manage the lifecycle on WiFi reconnects
+                udhcpc -b -i "$IFACE" -x hostname:"$HOSTNAME" &
+                REPLACED_IFACES="$REPLACED_IFACES $IFACE"
+                ;;
+        esac
     done
 done

--- a/files/4-apps/home/rinkhals/apps/10-hostname-dns/dhcp_watchdog.sh
+++ b/files/4-apps/home/rinkhals/apps/10-hostname-dns/dhcp_watchdog.sh
@@ -16,8 +16,6 @@ fi
 log "dhcp_watchdog: started, monitoring for hostname '$HOSTNAME'"
 
 while true; do
-    sleep $CHECK_INTERVAL
-
     REPLACED_IFACES=""
     for UDHCPC_PID in $(get_by_name udhcpc); do
         CMDLINE=$(cat "/proc/$UDHCPC_PID/cmdline" 2>/dev/null | tr '\0' ' ')
@@ -49,4 +47,6 @@ while true; do
                 ;;
         esac
     done
+
+    sleep $CHECK_INTERVAL
 done


### PR DESCRIPTION
## Summary

A follow-up for https://github.com/jbatonnet/Rinkhals/pull/436, the clone of https://github.com/jbatonnet/Rinkhals/pull/439. Adding a watchdog that kills rogue instances of udhcpc and restarts them with proper arguments.

## Why

The research shows that K3SysUi has the following strings:

```
adb shell strings /userdata/app/gk/K3SysUi | grep udhcp
udhcpc -i wlan0 &
ps | grep 'udhcpc.*-b.*-i wlan' | grep -v 'grep' | awk '{print $1}' | xargs kill -9 > /dev/null 2>&1
udhcpc -b -i wlan0 &
udhcpc -b -i %1
ps | grep 'udhcpc.*-b.*-i %s' | grep -v 'grep' | awk '{print $1}' | xargs kill -9 > /dev/null 2>&1
udhcpc -b -i %s > /dev/null 2>&1 &
```

It spawns `udhcpc` instances at arbitrary points. The current script doesn't recognize the new instances of udhcpc without `-H` arguments.

## Changes

- Added `dhcp_watchdog.sh`
- Fixed some shellcheck errors
- Using it in `10-hostname-dns`
- Change `log` function in `tools.sh` to print timestamps in both the log file and stdout

## Testing

How did you test this? Include printer model and firmware version if relevant.
For changes that affect hardware behaviour, manual verification on the target printer is strongly preferred.

- [x] Existing tests in `tests/` still pass (if applicable)
- [x] Manually tested on a real printer (Kobra3, 2.4.5 FW, 20260501_01 Rinkhals)
- [x] Documentation updated if user-visible behaviour changed

## Related issues

Fixes #
Related to https://github.com/jbatonnet/Rinkhals/pull/436

## Notes for reviewers

Anything reviewers should pay particular attention to. Risky areas, decisions you went back and forth on, open questions.
