### PR TITLE
fix(ui): apps checkbox sends correct toggle on every click

### DIFF
--- a/files/3-rinkhals/opt/rinkhals/ui/rinkhals-ui.py
+++ b/files/3-rinkhals/opt/rinkhals/ui/rinkhals-ui.py
@@ -542,7 +542,14 @@ class RinkhalsUiApp(BaseApp):
 
                 checkbox_app = lvr.checkbox(panel_app)
                 checkbox_app.align(lv.ALIGN.RIGHT_MID, -lv.dpx(5), 0)
-                checkbox_app.add_event_cb(lambda e, app=app, enabled=enabled: toggle_app(app, not enabled), lv.EVENT_CODE.CLICKED, None)
+                # Query ground truth on each click. The previous implementation
+                # captured `enabled` via a keyword default, which only reflects
+                # state at widget-creation time. After the first click flipped
+                # the app, subsequent clicks kept sending the same command
+                # (because the closure's `enabled` never updated), so users
+                # saw the checkbox stay in whatever state the first click left
+                # it in until they backed out and re-entered the Apps screen.
+                checkbox_app.add_event_cb(lambda e, app=app: toggle_app(app, is_app_enabled(app) != '1'), lv.EVENT_CODE.CLICKED, None)
                 checkbox_app.set_checked(enabled)
                 lv.unlock()
 


### PR DESCRIPTION
## Summary

Fixes a latent UI bug in the Apps screen on the touch panel. The per-app enable/disable checkbox handler captured the app's `enabled` state via a lambda keyword default, so it never re-read the current state on subsequent clicks. The first click correctly toggled the app; the second and subsequent clicks resent the same command (a no-op against the now-already-toggled state) and the checkbox visually appeared unresponsive.

Reported by a user trying to enable `60-firmware-collector` from the front panel. The app itself is healthy (CLI helpers work, daemon launches and runs), but the UI path was broken. The bug is **not** specific to firmware-collector. It affects every app's checkbox on the Apps list.

## What's happening

`rinkhals-ui.py:545` (before this fix):

```python
checkbox_app.add_event_cb(
    lambda e, app=app, enabled=enabled: toggle_app(app, not enabled),
    lv.EVENT_CODE.CLICKED, None
)
```

The `enabled=enabled` keyword default is bound **once**, when the widget is created during `refresh_apps`. It does not re-evaluate on subsequent clicks. The flow:

1. Page renders, `enabled` captures the app's state at render time.
2. User clicks. Handler runs `toggle_app(app, not enabled)`. App flips. `toggle_app` ends by calling `set_checked(is_app_enabled(app) == '1')`, so the visual matches reality.
3. User clicks again. Handler still computes `not enabled` against the **stale** captured value, sends the **same** command, which is now a no-op because the app is already in that state.
4. `set_checked(...)` still calls ground truth, so the checkbox correctly shows the unchanged state - it appears "stuck."

The workaround users discovered was to back out of the Apps screen and re-enter so the closures rebound with fresh state.

## Concrete evidence

User reported they could not enable `60-firmware-collector` from the touch panel. I caught the symptom in `rinkhals-ui.log`:

```
INFO:root:Disabling 60-firmware-collector...
INFO:root:Shell "disable_app 60-firmware-collector" => ""
INFO:root:Shell "get_app_status 60-firmware-collector" => "started"
INFO:root:Stopping 60-firmware-collector...
INFO:root:Shell "stop_app 60-firmware-collector" => "Killing 1211 (python3collector.py)"
INFO:root:Shell "is_app_enabled 60-firmware-collector" => "0"
INFO:root:Disabling 60-firmware-collector...
INFO:root:Shell "disable_app 60-firmware-collector" => ""
INFO:root:Shell "get_app_status 60-firmware-collector" => "stopped"
INFO:root:Shell "is_app_enabled 60-firmware-collector" => "0"
INFO:root:Disabling 60-firmware-collector...
INFO:root:Shell "disable_app 60-firmware-collector" => ""
INFO:root:Shell "get_app_status 60-firmware-collector" => "stopped"
INFO:root:Shell "is_app_enabled 60-firmware-collector" => "0"
```

Three taps in a row all interpreted as "disable" because `enabled` was captured as `True` at render time. First tap disabled correctly. Second and third taps were no-ops.

## The fix

Read ground truth at click time instead of relying on a captured value:

```python
checkbox_app.add_event_cb(
    lambda e, app=app: toggle_app(app, is_app_enabled(app) != '1'),
    lv.EVENT_CODE.CLICKED, None
)
```

One extra `is_app_enabled` shell call per click. Negligible cost next to the `enable_app`/`disable_app` shell call the handler is about to make anyway. The widget initial state (`checkbox_app.set_checked(enabled)` on the next line) is unchanged - that one is correctly using the render-time value as intended.

## Why it has been latent

Most users enable or disable an app once and leave it; the bug only shows up on a second toggle of the same widget without leaving the screen. The user who reported this was toggling repeatedly while debugging an unrelated symptom, which is how it surfaced.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` syntax check passes
- [ ] On a printer: tap an enabled app's checkbox repeatedly, verify it cleanly alternates between enabled and disabled with each click and the UI label flips accordingly
- [ ] On a printer: tap a disabled app's checkbox repeatedly, verify same behaviour starting from disabled
- [ ] On a printer: verify the original symptom (60-firmware-collector enable from touch panel) now works

## Out of scope

Per-app properties checkboxes elsewhere in the file (the `dry_run`-style enum checkboxes inside an app's detail screen) use the same closure-capture pattern around line 787. They might or might not exhibit the same bug depending on how they redraw. Worth a follow-up audit but not required for this fix to unblock the original report.