### PR TITLE
fix(moonraker): work around GoKlipper RESTART deadlock and heaters TypeError (#32)

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -1461,7 +1461,7 @@ class Kobra:
             try:
                 self.server.send_event(
                     'server:gcode_response',
-                    message + '\n'
+                    message
                 )
             except Exception as e:
                 logging.warning(f'[Kobra] Could not emit gcode_response: {e!r}')

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -157,6 +157,7 @@ class Kobra:
         self.patch_objects_list()
         self.patch_mainsail()
         self.patch_k2p_bug()
+        self.patch_klipper_restart()
         self.patch_ace_flush_control()
 
         logging.info('Completed Kobra patching! Yay!')
@@ -1344,6 +1345,36 @@ class Kobra:
         def wrap__request_standard(original__request_standard):
             async def _request_standard(me, web_request, timeout = None):
                 result = await original__request_standard(me, web_request, timeout)
+
+                if self.is_goklipper_running() and isinstance(result, dict) and 'status' in result:
+                    status = result['status']
+
+                    # Normalise heaters.available_monitors / .available_sensors
+                    # to lists. GoKlipper returns these as JSON null when the
+                    # respective collection is empty, rather than as []. Upstream
+                    # Moonraker's data_store._init_sensors does:
+                    #   self.temp_monitors = heaters.get("available_monitors", [])
+                    #   sensors.extend(self.temp_monitors)
+                    # dict.get(key, default) only substitutes the default when
+                    # the key is ABSENT; an explicit null returns None, and
+                    # sensors.extend(None) raises
+                    #   TypeError: 'NoneType' object is not iterable
+                    # The exception aborts _init_sensors before it issues the
+                    # heater subscription, which leaves the data store with no
+                    # source of temperature deltas. Every subsequent client
+                    # that subscribes to status updates then waits indefinitely
+                    # for status pushes that never come, which surfaces as
+                    # Mainsail/Fluidd hanging permanently after a RESTART or
+                    # FIRMWARE_RESTART (issue #32). Upstream Klipper either
+                    # omits the key or returns [], so this latent bug never
+                    # fires on real Klipper - normalising here keeps the
+                    # response shape consistent with what upstream expects.
+                    if 'heaters' in status and isinstance(status['heaters'], dict):
+                        heaters = status['heaters']
+                        for k in ('available_monitors', 'available_sensors', 'available_heaters'):
+                            if k in heaters and heaters[k] is None:
+                                heaters[k] = []
+
                 if self.is_goklipper_running() and 'status' in result and 'configfile' in result['status']:
                     configfile = result['status']['configfile']
 
@@ -1383,6 +1414,63 @@ class Kobra:
         logging.debug(f'  Before: {KlippyConnection._request_standard}')
         setattr(KlippyConnection, '_request_standard', wrap__request_standard(KlippyConnection._request_standard))
         logging.debug(f'  After: {KlippyConnection._request_standard}')
+
+    def patch_klipper_restart(self):
+        """
+        Intercept FIRMWARE_RESTART and RESTART.
+
+        GoKlipper's implementation of both gcodes deadlocks gklib internally:
+        the command is accepted, gklib logs `web hook do script: FIRMWARE_RESTART`,
+        and then gklib stops processing entirely. There are no further log
+        entries, no MCU reconnection, nothing. Moonraker's klippy_state stays
+        on `startup` indefinitely. Every klippy-touching RPC returns
+        "Method not found" until the printer is power-cycled (issue #32).
+
+        Because the deadlock is inside gklib itself - not in Moonraker, not in
+        our patches - there is no client-side recovery short of a full restart
+        of gklib. Killing gklib would let appCheck.sh respawn it but with the
+        stock printer.cfg (Rinkhals lives in rinkhals_gklib.cfg), which would
+        silently disable the Rinkhals layer until the next reboot.
+
+        The safest thing we can do is to refuse the command entirely so we
+        don't trigger the deadlock in the first place. Mainsail/Fluidd users
+        get an explanatory line in their console; the printer stays usable.
+
+        If they need to apply printer.cfg changes, a power-cycle is the
+        documented workaround. (`SHUTDOWN_MACHINE` or
+        `REBOOT_MACHINE` via the touch panel / power button still work.)
+
+        When stock Klipper is running we forward normally - this only fires
+        on GoKlipper.
+        """
+        async def handle_klipper_restart(args, delegate_run_gcode):
+            if not self.is_goklipper_running():
+                return await delegate_run_gcode()
+
+            message = (
+                '!! RESTART / FIRMWARE_RESTART is not supported on GoKlipper. '
+                'The command deadlocks gklib until the printer is power-cycled '
+                '(Rinkhals issue #32). To apply printer.cfg changes, reboot the '
+                'printer from the touch panel or power-cycle it.'
+            )
+            logging.warning('[Kobra] Refused RESTART/FIRMWARE_RESTART: %s', message)
+
+            # Surface the explanation in the Mainsail / Fluidd console.
+            # gcode_response is the standard channel for this kind of message;
+            # the leading '!!' makes Mainsail render it as a warning line.
+            try:
+                self.server.send_event(
+                    'server:gcode_response',
+                    message + '\n'
+                )
+            except Exception as e:
+                logging.warning(f'[Kobra] Could not emit gcode_response: {e!r}')
+
+            return None
+
+        logging.info('> Patching FIRMWARE_RESTART / RESTART...')
+        self.register_gcode_handler('FIRMWARE_RESTART', handle_klipper_restart)
+        self.register_gcode_handler('RESTART', handle_klipper_restart)
 
     def patch_k2p_bug(self):
         from .klippy_apis import KlippyAPI


### PR DESCRIPTION
Fixes #32.

## Background

Fabio reported that `RESTART` and `FIRMWARE_RESTART` permanently disconnect Mainsail and Fluidd on a KS1 Combo running stock 2.7.0.9 + Rinkhals 20260601_01. Refreshing the page does not recover; only a power cycle restores access. Reproduced live on a KS1 Combo running 2.7.2.1 + 20260601_02_test_webui.

Investigation traced two independent bugs hitting the same user-visible path. Both fixed here.

## Bug 1 — `data_store._init_sensors` TypeError (latent on every `klippy_ready`)

Upstream Moonraker (`components/data_store.py:80-83`):

```python
heaters: Dict[str, List[str]] = result.get("heaters", {})
sensors = heaters.get("available_sensors", [])
self.temp_monitors = heaters.get("available_monitors", [])
sensors.extend(self.temp_monitors)
```

GoKlipper returns `{"heaters": {"available_monitors": null, ...}}` &mdash; key present with explicit `null`. `dict.get(key, default)` only substitutes the default when the key is **absent**, so `temp_monitors` becomes `None` and `extend(None)` raises `TypeError: 'NoneType' object is not iterable`. Upstream Klipper either omits the key or returns `[]`, so this never fires there.

The exception aborts `_init_sensors` before `klippy_apis.subscribe_objects(sub)`, leaving the data store with no source of temperature deltas. This bug has been firing on every Rinkhals install on every `klippy_ready` event for a long time.

**Fix**: inside the existing `patch_mainsail._request_standard` wrap, normalise `heaters.available_monitors` / `.available_sensors` / `.available_heaters` from `null` to `[]` before downstream code reads them.

## Bug 2 &mdash; GoKlipper deadlocks `gklib` internally on `RESTART` / `FIRMWARE_RESTART`

Verified end-to-end:

1. `curl -X POST /printer/gcode/script?script=FIRMWARE_RESTART` returns HTTP 200.
2. `gklib` logs `web hook do script: FIRMWARE_RESTART`.
3. **`gklib` produces zero further log lines.** No MCU reconnection, no `klippy_ready`, no recovery.
4. After 3+ minutes `klippy_state` is still `startup`. Every Klippy-touching RPC returns `Method not found`.

The deadlock is inside `gklib` itself, not in Moonraker. Bug 1's fix does NOT resolve this symptom; even with `_init_sensors` running cleanly, Klippy never reaches `ready` because `gklib` is stuck.

We considered:

- Restarting `gklib` ourselves &mdash; `appCheck.sh` is **unpatched** and would respawn it with stock `printer.cfg` (Rinkhals lives in `rinkhals_gklib.cfg`), silently disabling the Rinkhals layer until the next reboot.
- Restarting just Moonraker via SIGTERM + supervisor respawn &mdash; recovers the API surface in ~7s but `klippy_state` stays stuck on `startup` because `gklib` never completes its restart.

The only safe response is to refuse the command before it triggers the deadlock.

**Fix**: new `patch_klipper_restart()` registers `FIRMWARE_RESTART` and `RESTART` as Rinkhals-handled gcodes (same handler-registry as `SDCARD_PRINT_FILE`, `CANCEL_PRINT`, `EXCLUDE_OBJECT`). The handler refuses without forwarding to `gklib` and emits an explanatory `gcode_response` warning that surfaces in the Mainsail / Fluidd console:

```
!! RESTART / FIRMWARE_RESTART is not supported on GoKlipper. The command
deadlocks gklib until the printer is power-cycled (Rinkhals issue #32).
To apply printer.cfg changes, reboot the printer from the touch panel
or power-cycle it.
```

When stock Klipper is running (`is_goklipper_running() == False`), the handler delegates to the original gcode path, so this is a no-op on non-Anycubic builds.

## Verification on a KS1 Combo (2.7.2.1 + 20260601_02_test_webui)

- `FIRMWARE_RESTART` via `/printer/gcode/script` returns HTTP 200 in 25ms.
- `klippy_state` stays `ready`; no startup-hang.
- `/printer/info` and `/printer/objects/query?webhooks` respond 200 immediately after.
- Explanatory message appears in the console for the user.
- `heaters.available_monitors` reads as `[]` (was `null`); no new TypeError fires after `patch_mainsail` installs the normalisation.

## Test plan

- [x] Reviewer pulls the branch on a Combo and runs `FIRMWARE_RESTART` from Mainsail. Mainsail stays connected; console shows the explanatory message.
- [x] Reviewer pulls the branch on a non-Combo (no ACE). Same behaviour.
- [x] Reviewer checks `moonraker.log` after a fresh boot for `TypeError` count. Should be zero.

## Out of scope

- Upstream Moonraker bug in `data_store._init_sensors`: we patch around it locally because changing the bundled Moonraker source is more invasive than the one-line response normalisation. Worth filing upstream as a separate issue (`.get(key, default)` semantics tripping on explicit-`None`).
- GoKlipper's `gklib` deadlock on `RESTART` / `FIRMWARE_RESTART`: this is an Anycubic firmware bug. The right long-term fix is for Anycubic to either implement the gcode correctly or document that it isn't supported.