### PR TITLE
fix: OrcaSlicer slot mapping desync and filament_colour_type crash

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -2405,8 +2405,6 @@ class MmuAcePatcher:
         if self.ace.enabled and "ams_settings" not in print_data:
 
             mapping = []
-            paint_index = 0  # paint_index counts the order of colors in the object (starts at 0)
-
             for tool_index, tool in enumerate(self.ace.tools):
                 gate_index = self.ace.ttg_map[tool_index]
 
@@ -2437,14 +2435,14 @@ class MmuAcePatcher:
                 # paint_index = order of colors in object (0, 1, 2, ...)
                 # ams_index = physical gate number (can be any gate)
                 mapping.append({
-                    "paint_index": paint_index,
+                    "paint_index": tool_index,
                     "ams_index": gate_index,
                     "paint_color": gate.color,
                     "ams_color": gate.color,
                     "material_type": gate.material
                 })
 
-                logging.info(f"Mapping: paint_index {paint_index} (T{tool_index}) → ams_index {gate_index} ({gate.filament_name})")
+                logging.info(f"Mapping: paint_index {tool_index} (T{tool_index}) → ams_index {gate_index} ({gate.filament_name})")
 
                 # Add backup gates from endless spool groups
                 if gate_index < len(self.ace.endless_spool_groups):
@@ -2466,16 +2464,14 @@ class MmuAcePatcher:
                             if backup_gate:
                                 # Add backup gate with same paint_index (same color) but different ams_index (gate)
                                 mapping.append({
-                                    "paint_index": paint_index,
+                                    "paint_index": tool_index,
                                     "ams_index": backup_gate_index,
                                     "paint_color": backup_gate.color,
                                     "ams_color": backup_gate.color,
                                     "material_type": backup_gate.material
                                 })
-                                logging.info(f"Endless Spool: paint_index {paint_index} (T{tool_index}) can use Gate {backup_gate_index} as backup for Gate {gate_index} (group {endless_spool_group})")
+                                logging.info(f"Endless Spool: paint_index {tool_index} (T{tool_index}) can use Gate {backup_gate_index} as backup for Gate {gate_index} (group {endless_spool_group})")
 
-                # Increment paint_index for the next color in the object
-                paint_index += 1
 
             if not mapping:
                 logging.info("No ACE gate mapping available, skipping AMS settings injection")

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace_metadata.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace_metadata.py
@@ -63,10 +63,16 @@ def parse_gcode_file(file_path):
         "total_toolchanges": total_toolchanges,
     }
 
+# Lines emitted by newer OrcaSlicer versions that Anycubic's Go firmware
+# (gklib) cannot parse — causes slice-bounds panic (error 10111).
+GCODE_STRIP_PREFIXES = ("; filament_colour_type",)
+
 def process_file(input_filename, output_filename, tools_used, total_toolchanges):
     with open(input_filename, 'r') as infile, open(output_filename, 'w') as outfile:
         outfile.write(f'{MMU_ACE_FINGERPRINT}\n')
         for line in infile:
+            if line.lstrip().startswith(GCODE_STRIP_PREFIXES):
+                continue
             outfile.write(line)
         # Append referenced tools metadata
         outfile.write("; referenced_tools = %s\n" % ",".join(map(str, tools_used)))


### PR DESCRIPTION
## Summary

Two bugs found and verified on Kobra 3 Max + ACE Pro 4-slot unit running Rinkhals `20260501_01` with OrcaSlicer 2.4.0-alpha. Both confirmed via live Moonraker logs and gcode inspection from the printer's Moonraker file API.

## Bug 1 — `filament_colour_type` crashes printer on print start

**File:** `mmu_ace_metadata.py`

Newer OrcaSlicer versions emit `; filament_colour_type = 0;1;1;1` in the gcode header. Anycubic's Go firmware (`gklib`) panics on this line:

runtime error: slice bounds out of range [:3] with length 1  (error 10111)

The `; filament_colour_type` key prefix-collides with `; filament_colour` (a `;`-delimited 4-value field). `gklib`'s header parser grabs the wrong line, slices it expecting 4 parts, gets 1 → Go panic. Print never starts.

**Fix:** Strip the line in `process_file()` before it reaches the printer. This runs on every upload via the `METADATA_SCRIPT` hook — any stock OrcaSlicer user is covered with zero per-machine configuration.

Related: jbatonnet/Rinkhals#407 (same Go panic, different trigger)

## Bug 2 — Wrong ACE slot fed when any gate between T0 and target is empty

Issue came up when I wanted to print petg on slot 3, but real print came from slot 4 PVA. Issue didnt happen when wanted to print with slot 1 PLA. Slot 2 was empty.

**File:** `mmu_ace.py`

`patch_print_data()` builds `ams_box_mapping` using a `paint_index` counter that **only increments for loaded (non-empty) gates**. When any gate between `T0` and the target tool reports `gate.status < 1`, the counter desyncs from the tool index.

`gklib` resolves a T-command to a physical slot by looking up `paint_index` in `ams_box_mapping`. With the desync:

Mapping: paint_index 0 (T0) → ams_index 0 (PLA)    ✓
Skipping empty gate 1 (tool 1) in ams_box_mapping   ← desync starts
Mapping: paint_index 1 (T2) → ams_index 2 (PETG)   ← stored as index 1
Mapping: paint_index 2 (T3) → ams_index 3 (PVA)    ← stored as index 2

`T2` (PETG) looks up `paint_index=2` → finds `ams_index=3` → feeds slot 4 (PVA) instead of slot 3 (PETG). Slot 1 (PLA) is correct only because nothing was skipped before it.

**Fix:** Use `tool_index` directly as `paint_index` so the mapping key always matches the T-command, regardless of which gates are empty.

## Testing

Verified on: Kobra 3 Max, Rinkhals `20260501_01`, OrcaSlicer `2.4.0-alpha`.
- Bug 1: print starts correctly with `filament_colour_type` present in gcode
- Bug 2: selecting slot 3 (PETG) with slot 2 empty now correctly feeds slot 3