### PR TITLE
fix(printer.cfg): override minimum_cruise_ratio to dodge GoKlipper NaN on KS1 2.7.2.7

### DIFF
--- a/files/3-rinkhals/home/rinkhals/printer_data/config/printer.rinkhals.cfg
+++ b/files/3-rinkhals/home/rinkhals/printer_data/config/printer.rinkhals.cfg
@@ -5,4 +5,30 @@ rename_existing: CANCEL_PRINT_BASE
 gcode:
   CANCEL_PRINT_BASE
 
+# Override Anycubic's default of 0 for minimum_cruise_ratio.
+# GoKlipper on Kobra S1 firmware 2.7.2.7 wedges its configfile.settings
+# JSON serializer with "json: unsupported value: NaN" whenever a websocket
+# client (moonraker, Mainsail, Fluidd) subscribes to configfile, because
+# some internal computation in the printer module produces NaN when
+# minimum_cruise_ratio is 0 (likely Inf-Inf or 0/0 in a derived motion
+# planning value). The result is that moonraker's klippy connection gets
+# permanently stuck on its first objects/query and Mainsail can never
+# subscribe to anything else either, so the printer is unreachable via
+# the web UIs until power-cycled.
+#
+# Setting minimum_cruise_ratio to a small non-zero value sidesteps the
+# NaN path entirely without meaningfully changing motion behaviour. With
+# 0.05 the derived max_accel_to_decel is max_accel * 0.95 (a 5% reduction
+# from stock), which is well below print-quality detection threshold.
+# Klipper's standard default for this parameter is 0.5, so 0.05 is much
+# closer to Anycubic's stock behaviour than to Klipper's default.
+#
+# Applies universally rather than gated to KS1 2.7.2.7. Other models
+# either don't have the bug (older firmwares) or will see the same 5%
+# max_accel_to_decel reduction. Users wanting stock Anycubic behaviour
+# can override this back in their own printer.custom.cfg, which is
+# merged after printer.rinkhals.cfg and wins on conflict.
+[printer]
+minimum_cruise_ratio: 0.05
+
 [include /useremain/home/rinkhals/printer_data/config/printer.custom.cfg]


### PR DESCRIPTION
## Summary

Kobra S1 owners who updated to Anycubic firmware `2.7.2.7` find Mainsail (and Fluidd) can't connect on Rinkhals `20260606_01`. The printer's touchscreen and gcode work fine, but every web UI gets stuck waiting on its initial configfile subscription. The release was pulled while we investigated.

## Root cause

GoKlipper on `2.7.2.7` produces `NaN` somewhere inside its `configfile.settings` dict. Go's `json.Marshal` refuses to encode `NaN`, the Send fails, the response never arrives, moonraker's klippy connection wedges on the first request, and every subsequent subscribe times out behind it.

Diagnosis bisected the NaN to the parsed-and-typed `configfile.settings` dict (the raw text `config`, `warnings`, and `save_config_pending` subfields all serialize fine). Binary diffing between `2.7.2.1` and `2.7.2.7` showed minor function-level changes, including a new `instantaneous_corner_velocity` field exposed in `Toolhead.Get_status`. The runtime toolhead status surfaced `minimum_cruise_ratio: 0` (Klipper's standard default is 0.5; Anycubic ships 0). Testing confirmed that overriding `minimum_cruise_ratio` to any non-zero value eliminates the NaN — the new 2.7.2.7 code derives a motion-planning value from it that produces NaN when the input is exactly zero.

## Fix

Add `[printer] minimum_cruise_ratio: 0.05` to `printer.rinkhals.cfg`. This applies universally:

- Other models either don't have the bug (older firmwares parse 0 fine) or see the same effect.
- `0.05` is the smallest round value comfortably above zero; derived `max_accel_to_decel` becomes `max_accel * 0.95` (a 5% reduction from stock), well below print-quality detection threshold.
- Klipper's standard default would be `0.5`, which would cut `max_accel_to_decel` in half — `0.05` keeps us much closer to Anycubic's stock behavior.
- Users who want stock behavior can override this back in their own `printer.custom.cfg` (merged after `printer.rinkhals.cfg`).

## Test plan

- [x] Confirm `configfile.settings` returns cleanly via direct UDS query on KS1 + 2.7.2.7 (was: timeout; now: 11 KB response in 60ms)
- [x] Confirm Mainsail loads and stays connected via `http://printer/`
- [x] Confirm toolhead reports `minimum_cruise_ratio: 0.05`, `max_accel_to_decel: 19000`
- [x] Confirm NaN count in `gklib.log` stays at 0 across reboot
