### PR TITLE
added 05-static-usb-ether-mac for overriding USB Ethernet MAC Address

### DIFF
--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/README.md
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/README.md
@@ -1,0 +1,53 @@
+# Static USB Ethernet MAC
+
+Override the MAC address of a USB Ethernet adapter connected to your printer. Useful for DHCP reservations or maintaining a consistent network identity across hardware swaps.
+
+## Compatible Adapters
+
+- ASIX AX88179 / AX88179A
+- Realtek RTL8153
+- ASIX AX88772
+
+## How It Works
+
+On startup, the app scans `/sys/class/net/eth*` to find the interface backed by a USB device (by checking `readlink -f /sys/class/net/<iface>/device` for a path containing `usb`). If a MAC address is configured and a USB Ethernet interface is found, it brings the interface down, applies the MAC with `ifconfig hw ether`, and brings it back up.
+
+The `05-` prefix ensures it runs before `10-hostname-dns`, so the MAC is set before DHCP and mDNS start.
+
+## Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| MAC address | *(empty)* | MAC address to apply to the USB Ethernet adapter (format: `aa:bb:cc:dd:ee:ff`) |
+
+## Set a Static MAC Address
+
+SSH into the printer and run:
+
+```bash
+source /useremain/rinkhals/.current/tools.sh
+set_app_property 05-static-usb-ether-mac mac_address aa:bb:cc:dd:ee:ff
+```
+
+The MAC address must be in colon-separated hexadecimal format (`xx:xx:xx:xx:xx:xx`). Invalid values are skipped and logged.
+
+Then restart the app (or reboot the printer):
+
+```bash
+/useremain/home/rinkhals/apps/05-static-usb-ether-mac/app.sh stop
+/useremain/home/rinkhals/apps/05-static-usb-ether-mac/app.sh start
+```
+
+## View the Current MAC Address
+
+```bash
+cat /sys/class/net/$(for iface in /sys/class/net/eth*; do
+    iface=$(basename $iface)
+    dev=$(readlink -f /sys/class/net/$iface/device 2>/dev/null)
+    case "$dev" in *usb*) echo "$iface"; break ;; esac
+done)/address
+```
+
+## Dependencies
+
+`ifconfig` from busybox/net-tools only — no additional packages required.

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.json
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.json
@@ -1,0 +1,15 @@
+{
+    "$version": "1",
+
+    "name": "Static USB Ethernet MAC",
+    "description": "Override the MAC address of a USB Ethernet adapter",
+    "version": "1.0",
+
+    "properties": {
+        "mac_address": {
+            "display": "MAC address",
+            "type": "text",
+            "default": ""
+        }
+    }
+}

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
@@ -1,0 +1,72 @@
+source /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname $(realpath $0))
+APP_NAME="05-static-usb-ether-mac"
+
+validate_mac() {
+    local MAC=$1
+    echo "$MAC" | grep -qE '^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$'
+}
+
+find_usb_eth() {
+    for IFACE in /sys/class/net/eth*; do
+        IFACE=$(basename $IFACE)
+        DEVICE=$(readlink -f /sys/class/net/$IFACE/device 2>/dev/null)
+        case "$DEVICE" in
+            *usb*) echo "$IFACE"; return ;;
+        esac
+    done
+}
+
+status() {
+    report_status $APP_STATUS_STOPPED
+}
+
+start() {
+    local MAC=$(get_app_property $APP_NAME mac_address)
+
+    if [ -z "$MAC" ]; then
+        log "No MAC address configured, skipping"
+        return
+    fi
+
+    if ! validate_mac "$MAC"; then
+        log "/!\ Invalid MAC address '$MAC', skipping"
+        return
+    fi
+
+    local IFACE=$(find_usb_eth)
+
+    if [ -z "$IFACE" ]; then
+        log "No USB Ethernet interface found, skipping"
+        return
+    fi
+
+    log "Setting MAC address of $IFACE to $MAC"
+
+    ifconfig $IFACE down
+    ifconfig $IFACE hw ether $MAC
+    ifconfig $IFACE up
+
+    log "MAC address of $IFACE set to $(cat /sys/class/net/$IFACE/address)"
+}
+
+stop() {
+    return 0
+}
+
+case "$1" in
+    status)
+        status
+        ;;
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {status|start|stop}" >&2
+        exit 1
+        ;;
+esac

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
@@ -18,27 +18,54 @@ find_usb_eth() {
     done
 }
 
+increment_mac() {
+    local MAC=$1
+    local LAST_BYTE=${MAC##*:}
+    local PREFIX=${MAC%:*}
+    local DEC=$((16#${LAST_BYTE}))
+    local NEW_DEC=$(( (DEC + 1) % 256 ))
+    local NEW_LAST=$(printf '%02x' $NEW_DEC)
+    echo "${PREFIX}:${NEW_LAST}"
+}
+
+resolve_mac() {
+    local MAC=$(get_app_property $APP_NAME mac_address)
+
+    if [ -n "$MAC" ]; then
+        echo "$MAC"
+        return
+    fi
+
+    if [ -f /userdata/ethaddr.txt ]; then
+        local FACTORY_MAC=$(cat /userdata/ethaddr.txt | tr -d ' \t\n\r')
+        if validate_mac "$FACTORY_MAC"; then
+            increment_mac "$FACTORY_MAC"
+            return
+        fi
+    fi
+}
+
 status() {
     report_status $APP_STATUS_STOPPED
 }
 
 start() {
-    local MAC=$(get_app_property $APP_NAME mac_address)
+    local IFACE=$(find_usb_eth)
+
+    if [ -z "$IFACE" ]; then
+        log "No USB Ethernet interface found, skipping"
+        return
+    fi
+
+    local MAC=$(resolve_mac)
 
     if [ -z "$MAC" ]; then
-        log "No MAC address configured, skipping"
+        log "No MAC address configured and no factory MAC found, skipping"
         return
     fi
 
     if ! validate_mac "$MAC"; then
         log "/!\ Invalid MAC address '$MAC', skipping"
-        return
-    fi
-
-    local IFACE=$(find_usb_eth)
-
-    if [ -z "$IFACE" ]; then
-        log "No USB Ethernet interface found, skipping"
         return
     fi
 

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
@@ -37,7 +37,7 @@ resolve_mac() {
     fi
 
     if [ -f /userdata/ethaddr.txt ]; then
-        local FACTORY_MAC=$(cat /userdata/ethaddr.txt | tr -d ' \t\n\r')
+        local FACTORY_MAC=$(cat /userdata/ethaddr.txt | tr -d ' \t\n\r' | tr 'A-F' 'a-f')
         if validate_mac "$FACTORY_MAC"; then
             increment_mac "$FACTORY_MAC"
             return


### PR DESCRIPTION

## Summary
Allows setting a static MAC-Address for USB Ethernet-Adapters with no NVMEM

## Why
Allows Setting Static DHCP leases in DHCP Server

## Changes

- Added App 05-static-usb-ether-mac

## Testing

How did you test this? Include printer model and firmware version if relevant.
For changes that affect hardware behaviour, manual verification on the target printer is strongly preferred.

- [ N/A] Existing tests in `tests/` still pass (if applicable)
- [ Kobra-S1 2.7.2.7 ] Manually tested on a real printer (model and firmware)
- [X] Documentation updated if user-visible behaviour changed


## Notes for reviewers
Mostly Vibe-Coded
