### PR TITLE
Speedup bed mesh calibration, embed homing

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -1169,8 +1169,10 @@ class Kobra:
                                     logging.info(f'[Kobra] Using leviQ3 extru_end_temp: {extru_end_temp}')
 
                         calibrate_script = [
-                            'MOVE_HEAT_POS',
+                            f'M104 S{extru_temp}', # Set hotend to 170
                             f'M140 S{bed_temp}', # Set bed to 60
+                            'G28', # Home all axes
+                            'MOVE_HEAT_POS',
                             f'M109 S{extru_temp}', # Wait hotend to 170
                             f'M190 S{bed_temp}', # Wait bed to 60
                             'WIPE_ENTER', # Move to wiping position


### PR DESCRIPTION
## Summary

The calibration requires first the axis homing, then it waits for the extruder and bed to heat up. Embedding the homing `G28` into the process allows for speeding it up by around 30-60 seconds.

## Why

Avoid pause between homing and calibration.

## Changes

Slight reorder of the wrapper for BED_MESH_CALIBRATE.

## Testing


- [ ] Existing tests in `tests/` still pass (if applicable)
- [x] Manually tested on a real printer (model and firmware)
- [ ] Documentation updated if user-visible behaviour changed

## Related issues

Fixes #
Related to #

## Notes for reviewers

Anything reviewers should pay particular attention to. Risky areas, decisions you went back and forth on, open questions.
