### PR TITLE
added app for static mac-address of usb-ethernet adapter

### DIFF
--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/README.md
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/README.md
@@ -10,7 +10,14 @@ Override the MAC address of a USB Ethernet adapter connected to your printer. Us
 
 ## How It Works
 
-On startup, the app scans `/sys/class/net/eth*` to find the interface backed by a USB device (by checking `readlink -f /sys/class/net/<iface>/device` for a path containing `usb`). If a MAC address is configured and a USB Ethernet interface is found, it brings the interface down, applies the MAC with `ifconfig hw ether`, and brings it back up.
+On startup, the app scans `/sys/class/net/eth*` to find the interface backed by a USB device (by checking `readlink -f /sys/class/net/<iface>/device` for a path containing `usb`). 
+
+The MAC address is resolved in this order:
+
+1. **Custom MAC** — if you configured one via the app property, it is used as-is
+2. **Derived MAC** — otherwise, the app reads the factory WiFi MAC from `/userdata/ethaddr.txt`, computes its MD5 hash, and takes the first 12 hex digits as the new MAC. The first byte's low nibble is sanitized to produce a valid IEEE 802 **locally-administered unicast** address (bit 1 = 1, bit 0 = 0), so the second hex digit is always `2`, `6`, `A`, or `E`. This guarantees no collision with any real vendor-assigned OUI.
+
+Once resolved, the interface is brought down, the MAC is applied with `ifconfig hw ether`, and the interface is brought back up.
 
 The `05-` prefix ensures it runs before `10-hostname-dns`, so the MAC is set before DHCP and mDNS start.
 
@@ -18,22 +25,18 @@ The `05-` prefix ensures it runs before `10-hostname-dns`, so the MAC is set bef
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| MAC address | *(empty)* | MAC address to apply to the USB Ethernet adapter (format: `aa:bb:cc:dd:ee:ff`) |
+| MAC address | *(empty)* | Custom MAC address to apply to the USB Ethernet adapter (format: `aa:bb:cc:dd:ee:ff`). If empty, a deterministic MAC is derived from the factory WiFi MAC. |
 
-## Default MAC Address
+## Set a Custom MAC Address
 
-If no MAC is set via SSH. MAC-Address in /userdata/ethaddr.txt (+1) is used by default.
-
-## Set a Custom Static MAC Address
-
-SSH into the printer and run:
+If you want a specific MAC instead of the derived one, SSH into the printer and run:
 
 ```bash
 source /useremain/rinkhals/.current/tools.sh
 set_app_property 05-static-usb-ether-mac mac_address aa:bb:cc:dd:ee:ff
 ```
 
-The MAC address must be in colon-separated lowercase hexadecimal format (`xx:xx:xx:xx:xx:xx`). Invalid values are skipped and logged.
+The MAC address must be in colon-separated hexadecimal format (`xx:xx:xx:xx:xx:xx`). Invalid values are skipped and logged.
 
 Then restart the app (or reboot the printer):
 
@@ -42,10 +45,8 @@ Then restart the app (or reboot the printer):
 /useremain/home/rinkhals/apps/05-static-usb-ether-mac/app.sh start
 ```
 
-*note* restarting the app will likly freeze you ssh session
-
 ## View the Current MAC Address
-/useremain/dev/device_id 
+
 ```bash
 cat /sys/class/net/$(for iface in /sys/class/net/eth*; do
     iface=$(basename $iface)
@@ -56,4 +57,4 @@ done)/address
 
 ## Dependencies
 
-`ifconfig` from busybox/net-tools only — no additional packages required.
+`ifconfig` from busybox/net-tools and `md5sum` — no additional packages required.

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/README.md
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/README.md
@@ -1,0 +1,59 @@
+# Static USB Ethernet MAC
+
+Override the MAC address of a USB Ethernet adapter connected to your printer. Useful for DHCP reservations or maintaining a consistent network identity across hardware swaps.
+
+## Compatible Adapters
+
+- ASIX AX88179 / AX88179A
+- Realtek RTL8153
+- ASIX AX88772
+
+## How It Works
+
+On startup, the app scans `/sys/class/net/eth*` to find the interface backed by a USB device (by checking `readlink -f /sys/class/net/<iface>/device` for a path containing `usb`). If a MAC address is configured and a USB Ethernet interface is found, it brings the interface down, applies the MAC with `ifconfig hw ether`, and brings it back up.
+
+The `05-` prefix ensures it runs before `10-hostname-dns`, so the MAC is set before DHCP and mDNS start.
+
+## Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| MAC address | *(empty)* | MAC address to apply to the USB Ethernet adapter (format: `aa:bb:cc:dd:ee:ff`) |
+
+## Default MAC Address
+
+If no MAC is set via SSH. MAC-Address in /userdata/ethaddr.txt (+1) is used by default.
+
+## Set a Custom Static MAC Address
+
+SSH into the printer and run:
+
+```bash
+source /useremain/rinkhals/.current/tools.sh
+set_app_property 05-static-usb-ether-mac mac_address aa:bb:cc:dd:ee:ff
+```
+
+The MAC address must be in colon-separated lowercase hexadecimal format (`xx:xx:xx:xx:xx:xx`). Invalid values are skipped and logged.
+
+Then restart the app (or reboot the printer):
+
+```bash
+/useremain/home/rinkhals/apps/05-static-usb-ether-mac/app.sh stop
+/useremain/home/rinkhals/apps/05-static-usb-ether-mac/app.sh start
+```
+
+*note* restarting the app will likly freeze you ssh session
+
+## View the Current MAC Address
+/useremain/dev/device_id 
+```bash
+cat /sys/class/net/$(for iface in /sys/class/net/eth*; do
+    iface=$(basename $iface)
+    dev=$(readlink -f /sys/class/net/$iface/device 2>/dev/null)
+    case "$dev" in *usb*) echo "$iface"; break ;; esac
+done)/address
+```
+
+## Dependencies
+
+`ifconfig` from busybox/net-tools only — no additional packages required.

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.json
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.json
@@ -1,0 +1,15 @@
+{
+    "$version": "1",
+
+    "name": "Static USB Ethernet MAC",
+    "description": "Override the MAC address of a USB Ethernet adapter",
+    "version": "1.0",
+
+    "properties": {
+        "mac_address": {
+            "display": "MAC address",
+            "type": "text",
+            "default": ""
+        }
+    }
+}

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
@@ -18,16 +18,6 @@ find_usb_eth() {
     done
 }
 
-increment_mac() {
-    local MAC=$1
-    local LAST_BYTE=${MAC##*:}
-    local PREFIX=${MAC%:*}
-    local DEC=$((16#${LAST_BYTE}))
-    local NEW_DEC=$(( (DEC + 1) % 256 ))
-    local NEW_LAST=$(printf '%02x' $NEW_DEC)
-    echo "${PREFIX}:${NEW_LAST}"
-}
-
 resolve_mac() {
     local MAC=$(get_app_property $APP_NAME mac_address)
 
@@ -36,13 +26,23 @@ resolve_mac() {
         return
     fi
 
-    if [ -f /userdata/ethaddr.txt ]; then
-        local FACTORY_MAC=$(cat /userdata/ethaddr.txt | tr -d ' \t\n\r' | tr 'A-F' 'a-f')
-        if validate_mac "$FACTORY_MAC"; then
-            increment_mac "$FACTORY_MAC"
-            return
-        fi
+    if [ ! -f /userdata/ethaddr.txt ]; then
+        return
     fi
+
+    local FACTORY_MAC=$(cat /userdata/ethaddr.txt | tr -d ' \t\n\r' | tr 'A-F' 'a-f')
+    if ! validate_mac "$FACTORY_MAC"; then
+        return
+    fi
+
+    local HASH=$(echo -n "$FACTORY_MAC" | md5sum | cut -c 1-12)
+    local FIRST_BYTE_HIGH=${HASH:0:1}
+    local FIRST_BYTE_LOW=${HASH:1:1}
+    local LOW_VAL=$((16#${FIRST_BYTE_LOW}))
+    local NEW_LOW=$(( (LOW_VAL & 0xC) | 0x2 ))
+    local NEW_LOW_HEX=$(printf '%x' $NEW_LOW)
+
+    echo "${FIRST_BYTE_HIGH}${NEW_LOW_HEX}:${HASH:2:2}:${HASH:4:2}:${HASH:6:2}:${HASH:8:2}:${HASH:10:2}"
 }
 
 status() {
@@ -60,7 +60,7 @@ start() {
     local MAC=$(resolve_mac)
 
     if [ -z "$MAC" ]; then
-        log "No MAC address configured and no factory MAC found, skipping"
+        log "No MAC address configured and unable to derive one, skipping"
         return
     fi
 

--- a/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
+++ b/files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh
@@ -1,0 +1,99 @@
+source /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname $(realpath $0))
+APP_NAME="05-static-usb-ether-mac"
+
+validate_mac() {
+    local MAC=$1
+    echo "$MAC" | grep -qE '^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$'
+}
+
+find_usb_eth() {
+    for IFACE in /sys/class/net/eth*; do
+        IFACE=$(basename $IFACE)
+        DEVICE=$(readlink -f /sys/class/net/$IFACE/device 2>/dev/null)
+        case "$DEVICE" in
+            *usb*) echo "$IFACE"; return ;;
+        esac
+    done
+}
+
+increment_mac() {
+    local MAC=$1
+    local LAST_BYTE=${MAC##*:}
+    local PREFIX=${MAC%:*}
+    local DEC=$((16#${LAST_BYTE}))
+    local NEW_DEC=$(( (DEC + 1) % 256 ))
+    local NEW_LAST=$(printf '%02x' $NEW_DEC)
+    echo "${PREFIX}:${NEW_LAST}"
+}
+
+resolve_mac() {
+    local MAC=$(get_app_property $APP_NAME mac_address)
+
+    if [ -n "$MAC" ]; then
+        echo "$MAC"
+        return
+    fi
+
+    if [ -f /userdata/ethaddr.txt ]; then
+        local FACTORY_MAC=$(cat /userdata/ethaddr.txt | tr -d ' \t\n\r' | tr 'A-F' 'a-f')
+        if validate_mac "$FACTORY_MAC"; then
+            increment_mac "$FACTORY_MAC"
+            return
+        fi
+    fi
+}
+
+status() {
+    report_status $APP_STATUS_STOPPED
+}
+
+start() {
+    local IFACE=$(find_usb_eth)
+
+    if [ -z "$IFACE" ]; then
+        log "No USB Ethernet interface found, skipping"
+        return
+    fi
+
+    local MAC=$(resolve_mac)
+
+    if [ -z "$MAC" ]; then
+        log "No MAC address configured and no factory MAC found, skipping"
+        return
+    fi
+
+    if ! validate_mac "$MAC"; then
+        log "/!\ Invalid MAC address '$MAC', skipping"
+        return
+    fi
+
+    log "Setting MAC address of $IFACE to $MAC"
+
+    ifconfig $IFACE down
+    ifconfig $IFACE hw ether $MAC
+    ifconfig $IFACE up
+
+    log "MAC address of $IFACE set to $(cat /sys/class/net/$IFACE/address)"
+}
+
+stop() {
+    return 0
+}
+
+case "$1" in
+    status)
+        status
+        ;;
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {status|start|stop}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds a new app 05-static-usb-ether-mac that overrides the MAC address of a USB Ethernet adapter. Falls back to the md5 hash of factory MAC (/userdata/ethaddr.txt) with first byte adjusted to represent a locally administered Address.

## Why

Some USB Ethernet adapters don't have a built-in MAC, so they get a random one each boot. This breaks DHCP reservations. The app auto-detects the USB Ethernet interface and assigns a deterministic MAC based on user Setting or the existing factory MAC ( from `/userdata/ethaddr.txt` )

## Changes

- Added files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.json — app manifest with mac_address property
- Added files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/app.sh — lifecycle script: detects USB eth via sysfs, resolves MAC (custom or factory+1), applies via ifconfig hw ether
- Added files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/.enabled — enabled by default  
- Added files/4-apps/home/rinkhals/apps/05-static-usb-ether-mac/README.md — usage and compatible adapter docs

## Testing

- Manually tested on a real printer (Kobra S1, RTL8153b adapter)
- Documentation updated if user-visible behaviour changed

## Related issues

N/A

## Notes for reviewers

The 05- prefix ensures the app runs before 10-hostname-dns so the MAC is set before DHCP/mDNS. MAC detection uses readlink -f /sys/class/net/ethX/device and checks for usb in the path — reliable for USB-attached Ethernet controllers
