### PR TITLE
fix(mmu_ace): preserve custom ttg_map across ACE status polls (#49)

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -1131,6 +1131,15 @@ class MmuAceController:
         ace = self.ace
         ace.units = []
         ace.tools = []
+
+        # Preserve any existing tool-to-gate map across status polls. This
+        # method runs on every ACE Hub status update (roughly every 20s), and
+        # unconditionally rebuilding ttg_map to the 1:1 default below silently
+        # discarded a user's custom mapping a few seconds after they set it
+        # (issue #49). We snapshot the current map here and, once the new
+        # topology is known, restore it if it still fits; otherwise we keep
+        # the freshly built default.
+        previous_ttg_map = list(ace.ttg_map)
         ace.ttg_map = []
 
         # Invalidate gate lookup cache when units change
@@ -1219,6 +1228,16 @@ class MmuAceController:
                 global_gate_index += 1
 
             self.ace.units.append(unit)
+
+        # Restore the previous tool-to-gate map if it still matches the
+        # current topology (same tool count, and every entry points at a gate
+        # that still exists). A custom mapping the user set via MMU_TTG_MAP
+        # therefore survives status polls, while an actual change in the
+        # number of gates (a unit added or removed) cleanly falls back to the
+        # 1:1 default that was just rebuilt above. See issue #49.
+        if (len(previous_ttg_map) == len(self.ace.ttg_map)
+                and all(0 <= gate_index < global_gate_index for gate_index in previous_ttg_map)):
+            self.ace.ttg_map = previous_ttg_map
 
         # Sync MMU status with ACE Hub current_filament state
         current_filament = filament_hub.get("current_filament", "")


### PR DESCRIPTION
## Summary

Fixes #49. A custom tool-to-gate mapping set in the Fluidd Tool Mapping dialog reverts to the default 1:1 assignment a few seconds after being applied.

## Root cause

`MmuAceController._set_ace_status()` runs on every ACE Hub status update (roughly every 20 seconds). It cleared `ttg_map` and rebuilt it as the 1:1 default (T0->0, T1->1, ...) while enumerating gates. A mapping set via `MMU_TTG_MAP` lives only in `self.ace.ttg_map`, so the next status poll silently discarded it. This is the applied-state counterpart to #9, which only addressed the dialog losing selection during input.

## Fix

Snapshot `ttg_map` before the rebuild and restore it after the new topology is enumerated, when it still fits: same tool count and every entry points at a gate that still exists. A genuine topology change (unit/gate added or removed) no longer matches and falls back to the freshly rebuilt default. `MMU_TTG_MAP RESET` still works because it sets the default explicitly.

The map remains in-memory only and does not survive a restart, which is unchanged.

## Test plan

- Set a custom mapping (e.g. T0->#0, T1->#3) in the Fluidd Tool Mapping dialog
- Wait through several ACE status polls (a minute or more)
- Confirm the mapping stays put instead of reverting to 1:1
- Physically add/remove an ACE unit and confirm the map resets to default for the new gate count
- Run `MMU_TTG_MAP RESET` and confirm it returns to 1:1
