### PR TITLE
Ensure stop() kills moonraker supervisor process

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/app.sh
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/app.sh
@@ -36,6 +36,7 @@ debug() {
     TMPDIR=/useremain/tmp HOME=/userdata/app/gk python ./moonraker/moonraker/moonraker.py -c /userdata/app/gk/printer_data/config/moonraker.generated.conf $@
 }
 stop() {
+    kill_by_name moonraker.sh
     kill_by_name moonraker.py
 }
 


### PR DESCRIPTION
## Summary

Fixes duplicate moonraker instances that were caused by app.sh stop() not killing their supervisors.

## Why

app.sh stop() ran only `kill_by_name moonraker.py`, killing the moonraker python but not its supervisor. So a "stop" did not actually stop moonraker, and any restart (stop_app + start_app to reload) left the old immortal supervisor to respawn its original moonraker instance and race to bind port :7125.

## Changes

- `40-moonraker/app.sh`: When stopping moonraker app, kill the supervisor first, then the python.

## Testing

This was reproduced and the fix verified on two different KS1 printers. Known compatible on KS1 / 2.7.2.7 running VK app.

- [ ] Existing tests in `tests/` still pass (if applicable)
- [x] Manually tested on a real printer (model and firmware)
- [ ] Documentation updated if user-visible behaviour changed

## Notes for reviewers

There is a separate open question on whether moonraker should ever be allowed to have more than one instance / immortal supervisor. If not, then moonraker.sh itself can be hardened with a single-instance guard.
