### PR TITLE
fix(mmu_ace): detect ACE cable disconnect and reconnect

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -662,6 +662,7 @@ class MmuAceController:
         self.ace.tools = []
         self.ace.ttg_map = []
         self._invalidate_gate_cache()
+        self._last_gate_fingerprint = ""  # force status push on next _set_ace_status
         self._handle_status_update(force=True)
 
     def _handle_status_update(self, force: bool = False, throttle: bool = False):
@@ -870,7 +871,15 @@ class MmuAceController:
                 klippy_apis: KlippyAPI = self.server.lookup_component("klippy_apis")
                 result = await klippy_apis.query_objects({ "filament_hub": None })
                 if not self._has_filament_hub_data(result):
-                    self._disable_ace("filament_hub object unavailable on this printer")
+                    self._disable_ace("ACE not connected at startup — will re-enable on reconnect")
+                    try:
+                        await self.printer.subscribe_objects(
+                            {"filament_hub": None},
+                            self._handle_mmu_ace_status_update
+                        )
+                        logging.info("[mmu_ace] Subscribed to filament_hub for reconnect detection")
+                    except Exception as sub_e:
+                        logging.warning(f"[mmu_ace] Could not subscribe for reconnect detection: {sub_e}")
                     return
                 success = True
             except Exception as e:
@@ -925,7 +934,10 @@ class MmuAceController:
             return
 
         try:
-            result = await self.printer.subscribe_objects({ "filament_hub": None }, self._handle_mmu_ace_status_update)
+            result = await self.printer.subscribe_objects(
+                {"filament_hub": None},
+                self._handle_mmu_ace_status_update
+            )
         except Exception as e:
             if self._is_no_ace_error(e):
                 self._disable_ace(str(e))
@@ -984,6 +996,7 @@ class MmuAceController:
                 return
 
             if "filament_hubs" not in filament_hub:
+                # Partial update: filament_hubs unchanged, only current_filament may have changed
                 current_filament = filament_hub.get("current_filament")
 
                 if current_filament is not None:
@@ -994,6 +1007,16 @@ class MmuAceController:
                         "Ignoring partial filament_hub update without current_filament: "
                         f"{list(filament_hub.keys())}"
                     )
+                return
+
+            filament_hubs = filament_hub["filament_hubs"]
+
+            if not isinstance(filament_hubs, list):
+                # filament_hubs=null: ACE cable disconnected at runtime.
+                # GoKlipper sends filament_hubs=[...] on reconnect.
+                # subscription callback handles re-enable automatically.
+                if self.ace.enabled:
+                    self._disable_ace("ACE cable disconnected (filament_hubs=null)")
                 return
 
             # Fetch temperature info for all gates with material
@@ -1228,6 +1251,11 @@ class MmuAceController:
                 global_gate_index += 1
 
             self.ace.units.append(unit)
+
+        # Re-enable if ACE reconnected while it was disabled on the _disable_ace()
+        if ace.units and not ace.enabled:
+            logging.info("[mmu_ace] ACE reconnected — re-enabling")
+            ace.enabled = True
 
         # Restore the previous tool-to-gate map if it still matches the
         # current topology (same tool count, and every entry points at a gate

--- a/tests/test_mmu_ace.py
+++ b/tests/test_mmu_ace.py
@@ -231,6 +231,101 @@ class MmuAcePartialUpdateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.status_updates, [])
 
 
+class MmuAceDisconnectReconnectTests(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_mmu_ace_module()
+
+    def setUp(self):
+        self.original_create_task = self.module.asyncio.create_task
+        self.module.asyncio.create_task = lambda coro: DummyTask(coro)
+        self.server = DummyServer()
+        self.controller = self.module.MmuAceController(self.server, host=None)
+        self.controller.ace = self.module.MmuAce()
+        self.status_updates = []
+        self.controller._handle_status_update = lambda *args, **kwargs: self.status_updates.append(kwargs)
+
+    def tearDown(self):
+        self.module.asyncio.create_task = self.original_create_task
+
+    def _build_filament_hub(self, current_filament: str = ""):
+        return {
+            "current_filament": current_filament,
+            "filament_hubs": [
+                {
+                    "id": 0,
+                    "status": "ready",
+                    "temp": 25,
+                    "slots": [
+                        {"index": 0, "status": "ready", "sku": "", "type": "PLA", "color": [255, 255, 255], "rfid": 1, "source": 2},
+                        {"index": 1, "status": "empty", "sku": "", "type": "", "color": [0, 0, 0], "rfid": 1, "source": 3},
+                        {"index": 2, "status": "empty", "sku": "", "type": "", "color": [0, 0, 0], "rfid": 1, "source": 3},
+                        {"index": 3, "status": "empty", "sku": "", "type": "", "color": [0, 0, 0], "rfid": 1, "source": 3},
+                    ],
+                }
+            ],
+        }
+
+    async def test_disconnect_disables_ace(self):
+        self.controller.ace.enabled = True
+
+        await self.controller._handle_mmu_ace_status_update(
+            {"filament_hub": {"filament_hubs": None}},
+            0.0,
+        )
+
+        self.assertFalse(self.controller.ace.enabled)
+        self.assertEqual(self.status_updates, [{"force": True}])
+
+    async def test_disconnect_when_already_disabled_is_idempotent(self):
+        self.controller.ace.enabled = False
+
+        await self.controller._handle_mmu_ace_status_update(
+            {"filament_hub": {"filament_hubs": None}},
+            0.0,
+        )
+
+        self.assertFalse(self.controller.ace.enabled)
+        self.assertEqual(self.status_updates, [])
+
+    def test_reconnect_reenables_ace_in_set_ace_status(self):
+        self.controller.ace.enabled = False
+
+        self.controller._set_ace_status(self._build_filament_hub())
+
+        self.assertTrue(self.controller.ace.enabled)
+
+    def test_set_ace_status_does_not_reenable_when_already_enabled(self):
+        self.controller.ace.enabled = True
+
+        self.controller._set_ace_status(self._build_filament_hub())
+
+        self.assertTrue(self.controller.ace.enabled)
+
+    def test_disable_ace_resets_gate_fingerprint(self):
+        self.controller._last_gate_fingerprint = "gate0:PLA|gate1:ASA"
+
+        self.controller._disable_ace("test disconnect")
+
+        self.assertEqual(self.controller._last_gate_fingerprint, "")
+
+    def test_first_status_after_reconnect_is_not_suppressed_by_dedup(self):
+        # Simulate state just before reconnect: fingerprint has stale data
+        # identical to what the ACE will report on reconnect
+        self.controller._set_ace_status(self._build_filament_hub())
+        self.status_updates.clear()
+
+        # Cable pulled — fingerprint reset, ace disabled
+        self.controller._disable_ace("cable disconnected")
+        self.status_updates.clear()
+
+        # Cable replugged — same gate data as before disconnect
+        self.controller._set_ace_status(self._build_filament_hub())
+
+        # Must push an update even though data is identical to pre-disconnect
+        self.assertEqual(self.status_updates, [{"force": True}])
+
+
 class MmuRecoverTests(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Summary

What does this PR do? Two or three sentences.

Intercept `filament_hubs=null` and `disable_ace()` early. Re-enable ACE when `_set_ace_status()` handle is fired but ace is still disabled. Subscribe to `filament_hub` at startup if ACE is connect or not. `_last_gate_fingerptint` solve edge case where after ACE reconnect first status is never suppressed by dedup check.

## Why

Currently after the disconnect the status of the ACE is never updated. So the Fluidd or Mainsail shows the MMU as disabled and thus require full restart / reboot. This PR fixes that and handles update ACE status.

## Changes

mmu_ace.py
-  intercept `filament_hubs=null` in `_handle_mmu_ace_status_update()` and call `_disable_ace()` before reaching `_set_ace_status()`
- re-enable ACE in `_set_ace_status()` when `ace.units` is populated but `ace.enabled=False` (reconnect path)
- subscribe to `filament_hub` at startup even when ACE is not present, so a cable plugged in after boot is detected without a restart
-  reset `_last_gate_fingerprint` in `_disable_ace()` so the first status push after reconnect is never suppressed by the dedup check

## Testing

- [x] Existing tests in `tests/` still pass (if applicable)
- [x] Manually tested on Anycubic Kobra S1 Max, stock firmware 2.6.9.3, Rinkhals 20260601_02

## Related issues

Fixes #
Related to #

## Notes for reviewers

The reconnect path relies entirely on the existing subscription callback — GoKlipper was confirmed to reliably send `filament_hubs=[...]` on reconnect across multiple test cycles on KS1M firmware 2.6.9.3. The `_last_gate_fingerprint` reset is required because on reconnect the gate data is identical to pre-disconnect, which would suppress the status push to clients without the reset.