### PR TITLE
feat(web-portal): serve on port 80, drop Mainsail/Fluidd socat redirects

### DIFF
--- a/docs/docs/about/index.md
+++ b/docs/docs/about/index.md
@@ -34,8 +34,10 @@ Additionally, Kobra X SWU updates appear to require certificate validation. Unti
 
 TLDR:
 - SSH on port 22 (root: rockchip except for K3M)
-- Mainsail on port 80 and 4409
+- Rinkhals web portal on port 80 (the printer's bare IP) and port 8090
+- Mainsail on port 4409
 - Fluidd on port 4408
+- Moonraker API on port 7125 (use this for OrcaSlicer and other slicer/automation uploads)
 
 
 ## Features and built-in apps
@@ -113,25 +115,20 @@ By default, those settings are all disabled for every print. This behavior can b
 
 Mainsail is a web interface for Klipper-based printers. It connects to Moonraker over web API and websocket to expose live control and metrics.
 
-It's a SPA (Single Page Application) served using [Lighttpd](https://www.lighttpd.net) web server. Replication on port 80 is done using socat to keep memory consumption as low as possible.
+It's a SPA (Single Page Application) served using [Lighttpd](https://www.lighttpd.net) web server on port 4409.
 
 Lighttpd is also configured to expose up to 4 cameras proxying to mjpg-streamer. Cameras are accessible using /webcam or /webcam0 for the first one, then /webcam1, /webcam2 and /webcam3 for the other.
 
 !!! note
 
-    Port 80 is dynamically allocated depending on the order of app startup.
-    By default during their startup, Mainsail and Fluidd will try to use port 80. This is made to ensure that you can expose multiple frontends while choosing which one is using port 80.
-
-!!! tip
-
-    It is possible to expose another interface on port 80.
-    Make sure that your custom app open and listens to port 80 before Mainsail and/or Fluidd by using a name prefix with a number below 25.
+    Port 80 (the printer's bare IP) is served by the Rinkhals web portal (65-rinkhals-web), which links to Mainsail, Fluidd and the other tools from its dashboard.
+    Earlier builds redirected port 80 to Mainsail or Fluidd using a per-connection socat process; that redirect has been removed in favor of the web portal owning port 80 directly. Mainsail and Fluidd are now reached on their own ports (4409 and 4408).
 
 | 25-mainsail | |
 |-|-|
 | App manifest | [app.json](https://github.com/rinkhals-community/Rinkhals/blob/master/files/4-apps/home/rinkhals/apps/25-mainsail/app.json) |
 | Default state | Enabled |
-| Port | 4409, 80* |
+| Port | 4409 |
 | CPU usage | 0 ~ 3 % |
 | Memory usage | 1 ~ 4 MB |
 
@@ -146,7 +143,7 @@ Please refer to Mainsail documentation above as the behavior is exactly the same
 |-|-|
 | App manifest | [app.json](https://github.com/rinkhals-community/Rinkhals/blob/master/files/4-apps/home/rinkhals/apps/26-fluidd/app.json) |
 | Default state | Enabled |
-| Port | 4409, 80* |
+| Port | 4408 |
 | CPU usage | 0 ~ 3 % |
 | Memory usage | 1 ~ 4 MB |
 

--- a/docs/docs/about/installation-and-firmware-updates.md
+++ b/docs/docs/about/installation-and-firmware-updates.md
@@ -66,7 +66,7 @@ On the Kobra series of 3D printer, it's possible to sideload .swu files to insta
 - The printer will reboot twice and beep both times.
     - If you have a Rinkhals icon in the settings tab then Rinkhals is installed.
     - If you don't have Rinkhals icon in the settings tab:
-        - First test if Moonsail is running on `http://YOUR_PRINTER_IP` if not then the installation failed.
+        - First test if the Rinkhals web portal is running on `http://YOUR_PRINTER_IP` (default login `admin` / `rinkhals`). If it doesn't load, the installation failed.
 
 
 ## How to uninstall Rinkhals

--- a/docs/docs/guides/orca-slicer-usage.md
+++ b/docs/docs/guides/orca-slicer-usage.md
@@ -28,7 +28,11 @@ Click the **Connection** button in the printer section on the left side.
 
 ![Connection Button](https://raw.githubusercontent.com/Rickeetz/Rinkhals/master/docs/docs/assets/orca-guide/Connection.png)
 
-Enter the local IP address of your printer and click the **Test** button.
+In the **Hostname, IP or URL** field, enter your printer's address including the Moonraker port: `http://YOUR_PRINTER_IP:7125`. Leave the API Key empty. Click the **Test** button.
+
+!!! warning Use port 7125, not the bare IP
+
+    OrcaSlicer's OctoPrint host type defaults to port 80. On Rinkhals, port 80 (the bare printer IP) now serves the password-protected Rinkhals web portal, so pointing OrcaSlicer at just the IP will fail to connect. Moonraker exposes an OctoPrint-compatible API directly on port 7125, so connect there instead. Mainsail (port 4409) and Fluidd (port 4408) proxy to the same Moonraker API if you prefer to use one of those addresses.
 
 !!! note Tip
 
@@ -47,8 +51,9 @@ If you encounter this error:
 
 ![Cannot Connect Error](https://raw.githubusercontent.com/Rickeetz/Rinkhals/master/docs/docs/assets/orca-guide/Cannot-Connect-Port80-Orca.png)
 
-Make sure your computer is connected to the same network as your printer. 
-Also, ensure you are using Fluidd or Mainsail as a WebUI and have the necessary apps for those services activated.
+- Make sure your computer is connected to the same network as your printer.
+- Make sure the address includes the Moonraker port, `:7125`. The bare printer IP now serves the password-protected Rinkhals web portal, not the printer API, so a connection to just the IP (port 80) will fail like this.
+- Make sure Moonraker is running (the 40-moonraker app is enabled).
 
 Click **OK** on the settings screen.
 

--- a/docs/docs/guides/rinkhals-quick-start.md
+++ b/docs/docs/guides/rinkhals-quick-start.md
@@ -57,12 +57,19 @@ Or:
 - Your IP should be shown here
 
 
+## The Rinkhals web portal
+
+Open your browser to http://YOUR_PRINTER_IP (the printer's bare IP) to open the Rinkhals web portal. The default login is `admin` / `rinkhals`, and you will be prompted to set your own password. From the portal dashboard you can reach Mainsail, Fluidd and the other tools.
+
 ## To use Mainsail or Fluidd, the web interfaces
 
-Open your browser to http://YOUR_PRINTER_IP to open the web interface (Mainsail by default).
-From there you'll be able to control your printer.
+Mainsail is at http://YOUR_PRINTER_IP:4409 and Fluidd (when enabled) is at http://YOUR_PRINTER_IP:4408. From there you'll be able to control your printer.
 
 Please refer to Mainsail documentation for more information: [https://docs.mainsail.xyz](https://docs.mainsail.xyz)
+
+!!! note
+
+    Earlier builds opened Mainsail directly from the bare printer IP (port 80). That address now serves the Rinkhals web portal, and Mainsail/Fluidd live on ports 4409 and 4408. If you upload from a slicer, point it at Moonraker on port 7125 (see the [OrcaSlicer guide](orca-slicer-usage.md)).
 
 
 ## To directly print from Orca or OctoApp

--- a/files/4-apps/home/rinkhals/apps/25-mainsail/app.sh
+++ b/files/4-apps/home/rinkhals/apps/25-mainsail/app.sh
@@ -29,20 +29,14 @@ start() {
         echo $PID > /tmp/rinkhals/mainsail.pid
     fi
 
-    socat TCP-LISTEN:80,reuseaddr,fork TCP:localhost:4409 &> /dev/null &
-    PID=$!
-    if [ "$?" == 0 ]; then
-        echo $PID > /tmp/rinkhals/mainsail-80.pid
-    fi
+    # Port 80 is now served by the Rinkhals web portal (65-rinkhals-web), so the
+    # old socat redirect from :80 to Mainsail's :4409 has been removed. Mainsail
+    # stays reachable on http://<printer-ip>:4409.
 }
 stop() {
     PID=$(cat /tmp/rinkhals/mainsail.pid 2> /dev/null)
     kill_by_id $PID
     rm /tmp/rinkhals/mainsail.pid 2> /dev/null
-
-    PID=$(cat /tmp/rinkhals/mainsail-80.pid 2> /dev/null)
-    kill_by_id $PID
-    rm /tmp/rinkhals/mainsail-80.pid 2> /dev/null
 }
 
 case "$1" in

--- a/files/4-apps/home/rinkhals/apps/26-fluidd/app.sh
+++ b/files/4-apps/home/rinkhals/apps/26-fluidd/app.sh
@@ -29,20 +29,14 @@ start() {
         echo $PID > /tmp/rinkhals/fluidd.pid
     fi
 
-    socat TCP-LISTEN:80,reuseaddr,fork TCP:localhost:4408 &> /dev/null &
-    PID=$!
-    if [ "$?" == 0 ]; then
-        echo $PID > /tmp/rinkhals/fluidd-80.pid
-    fi
+    # Port 80 is now served by the Rinkhals web portal (65-rinkhals-web), so the
+    # old socat redirect from :80 to Fluidd's :4408 has been removed. Fluidd
+    # stays reachable on http://<printer-ip>:4408.
 }
 stop() {
     PID=$(cat /tmp/rinkhals/fluidd.pid 2> /dev/null)
     kill_by_id $PID
     rm /tmp/rinkhals/fluidd.pid 2> /dev/null
-
-    PID=$(cat /tmp/rinkhals/fluidd-80.pid 2> /dev/null)
-    kill_by_id $PID
-    rm /tmp/rinkhals/fluidd-80.pid 2> /dev/null
 }
 
 case "$1" in

--- a/files/4-apps/home/rinkhals/apps/65-rinkhals-web/web_server.go
+++ b/files/4-apps/home/rinkhals/apps/65-rinkhals-web/web_server.go
@@ -497,11 +497,22 @@ func startWebServer() {
 
 	mux.Handle("/", http.FileServer(http.FS(uiFS)))
 
-	log.Println("Starting Rinkhals Web Portal on :8090")
+	log.Println("Starting Rinkhals Web Portal on :80 (and :8090 for backward compatibility)")
 
 	handler := corsMiddleware(basicAuthMiddleware(mux))
 
-	if err := http.ListenAndServe(":8090", handler); err != nil {
-		log.Fatalf("HTTP server failed: %v", err)
+	// The portal now owns port 80, so the printer's bare IP opens it directly.
+	// This replaces the per-connection socat redirect that Mainsail/Fluidd used
+	// to point port 80 at their own web servers. We run as root, so binding the
+	// privileged port is fine. :8090 is kept for one transition cycle so existing
+	// bookmarks (and the Vite dev workflow) keep working; it can be dropped later.
+	go func() {
+		if err := http.ListenAndServe(":8090", handler); err != nil {
+			log.Printf("HTTP server on :8090 failed: %v", err)
+		}
+	}()
+
+	if err := http.ListenAndServe(":80", handler); err != nil {
+		log.Fatalf("HTTP server on :80 failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Moves the Rinkhals web portal to **port 80** so the printer's bare IP opens it directly, and removes the per-connection **socat** redirects that Mainsail and Fluidd used to put themselves on port 80.

## Why

The socat redirect (`socat TCP-LISTEN:80,reuseaddr,fork TCP:localhost:44xx`) forks a process per connection and copies every byte through userspace. It was only ever a convenience to reach the *human* Mainsail/Fluidd UI at the bare IP; slicer and automation uploads go to Moonraker, not through it.

The kernel-level alternative (iptables/nftables REDIRECT) is **not available** on this hardware: the vendor kernel has no netfilter at all (no `nat` or even `filter` table, no loadable modules, no `modprobe`), same as the missing swap/cron/ftrace. Since `rinkhals-web` is our own process running as root, the lightest possible solution is to bind port 80 directly, which is what this does.

## Changes

- `65-rinkhals-web/web_server.go`: listen on `:80` (primary) and keep `:8090` (goroutine) for one transition cycle, so existing bookmarks and the Vite dev workflow keep working.
- `25-mainsail/app.sh`, `26-fluidd/app.sh`: remove the socat `:80` redirect and its pid handling. Mainsail stays on `:4409`, Fluidd on `:4408`.
- Docs: bare IP is now the web portal; Mainsail/Fluidd move to their own ports; architecture doc updated; and the **OrcaSlicer guide now points slicer uploads at Moonraker's OctoPrint-compatible API on `:7125`**.

## User-facing impact (call out in the release notes and Discord)

- **Bare printer IP now opens the Rinkhals web portal** (login `admin`/`rinkhals`), not Mainsail.
- **Mainsail/Fluidd move to `:4409` / `:4408`.**
- **OrcaSlicer users must repoint** their OctoPrint host from the bare IP to `http://<printer-ip>:7125` (Moonraker). OrcaSlicer defaults to port 80, which is now the password-protected portal, so the old bare-IP setup will fail. The OrcaSlicer guide is updated accordingly.
- `:8090` still works this cycle and can be dropped in a later release.

## Testing notes

- `go build` / `go vet` clean.
- Not yet validated on hardware for the `:80` bind + socat removal end-to-end; worth confirming on a printer that the portal answers on the bare IP, Mainsail is reachable on `:4409`, and an OrcaSlicer upload to `:7125` works, before this rides into a stable release.

## Follow-up

- Announce the port change on Discord when this ships.
- Consider dropping `:8090` in a subsequent release once users have migrated.
