### PR TITLE
fix(sounds): restore pwm0 state after tones so touchscreen key sound keeps working

### DIFF
--- a/files/3-rinkhals/opt/rinkhals/tools/backup-partitions.sh
+++ b/files/3-rinkhals/opt/rinkhals/tools/backup-partitions.sh
@@ -33,6 +33,7 @@ sync
 # Play ok jingle to notify completion
 if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 120000; echo 0 > $B/enable; usleep 40000
@@ -42,4 +43,6 @@ if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     echo 0 > $B/duty_cycle
     echo 1517000 > $B/period; echo 606800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 fi

--- a/files/3-rinkhals/opt/rinkhals/tools/clean-rinkhals.sh
+++ b/files/3-rinkhals/opt/rinkhals/tools/clean-rinkhals.sh
@@ -30,6 +30,7 @@ sync
 # Play ok jingle to notify completion
 if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 120000; echo 0 > $B/enable; usleep 40000
@@ -39,4 +40,6 @@ if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     echo 0 > $B/duty_cycle
     echo 1517000 > $B/period; echo 606800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 fi

--- a/files/3-rinkhals/opt/rinkhals/tools/config-reset.sh
+++ b/files/3-rinkhals/opt/rinkhals/tools/config-reset.sh
@@ -8,6 +8,7 @@ UPDATE_PATH="/useremain/update_swu"
 if [ ! -e /useremain/rinkhals/.current ]; then
     if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
         B=/sys/class/pwm/pwmchip0/pwm0
+        SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
         echo 0 > $B/enable; echo 0 > $B/duty_cycle
         echo 3817000 > $B/period; echo 1526800 > $B/duty_cycle; echo 1 > $B/enable
         usleep 300000; echo 0 > $B/enable; usleep 100000
@@ -17,6 +18,8 @@ if [ ! -e /useremain/rinkhals/.current ]; then
         echo 0 > $B/duty_cycle
         echo 5714000 > $B/period; echo 2285600 > $B/duty_cycle; echo 1 > $B/enable
         usleep 600000; echo 0 > $B/enable
+        # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+        echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
     fi
     exit 1
 fi
@@ -60,6 +63,7 @@ sync
 # Play ok jingle to notify completion
 if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 120000; echo 0 > $B/enable; usleep 40000
@@ -69,4 +73,6 @@ if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     echo 0 > $B/duty_cycle
     echo 1517000 > $B/period; echo 606800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 fi

--- a/files/3-rinkhals/opt/rinkhals/tools/debug-bundle.sh
+++ b/files/3-rinkhals/opt/rinkhals/tools/debug-bundle.sh
@@ -93,6 +93,7 @@ sync
 # Play ok jingle to notify completion
 if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 120000; echo 0 > $B/enable; usleep 40000
@@ -102,4 +103,6 @@ if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     echo 0 > $B/duty_cycle
     echo 1517000 > $B/period; echo 606800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 fi

--- a/files/3-rinkhals/opt/rinkhals/tools/factory-reset.sh
+++ b/files/3-rinkhals/opt/rinkhals/tools/factory-reset.sh
@@ -15,6 +15,7 @@
 # Play ok jingle to notify completion
 if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 120000; echo 0 > $B/enable; usleep 40000
@@ -24,4 +25,6 @@ if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     echo 0 > $B/duty_cycle
     echo 1517000 > $B/period; echo 606800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 fi

--- a/files/3-rinkhals/opt/rinkhals/tools/rinkhals-uninstall.sh
+++ b/files/3-rinkhals/opt/rinkhals/tools/rinkhals-uninstall.sh
@@ -42,6 +42,7 @@ fi
 # Play ok jingle to notify completion
 if [ "$MUTE_SOUNDS" = "0" ]; then
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 120000; echo 0 > $B/enable; usleep 40000
@@ -51,6 +52,8 @@ if [ "$MUTE_SOUNDS" = "0" ]; then
     echo 0 > $B/duty_cycle
     echo 1517000 > $B/period; echo 606800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 fi
 
 sync 2> /dev/null

--- a/files/3-rinkhals/start.sh
+++ b/files/3-rinkhals/start.sh
@@ -13,6 +13,7 @@ quit() {
 
     if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
         B=/sys/class/pwm/pwmchip0/pwm0
+        SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
         echo 0 > $B/enable; echo 0 > $B/duty_cycle
         echo 3817000 > $B/period; echo 1526800 > $B/duty_cycle; echo 1 > $B/enable
         usleep 300000; echo 0 > $B/enable; usleep 100000
@@ -22,6 +23,8 @@ quit() {
         echo 0 > $B/duty_cycle
         echo 5714000 > $B/period; echo 2285600 > $B/duty_cycle; echo 1 > $B/enable
         usleep 600000; echo 0 > $B/enable
+        # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+        echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
     fi
 
     ./stop.sh
@@ -375,11 +378,14 @@ log "Rinkhals started"
 
 ta_da() {
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable; usleep 50000
     echo 0 > $B/duty_cycle
     echo 1912000 > $B/period; echo 764800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 280000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 }
 [ -f /useremain/rinkhals/.mute-sounds ] || ta_da &

--- a/files/update.sh
+++ b/files/update.sh
@@ -85,6 +85,7 @@ quit() {
 
     if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
         B=/sys/class/pwm/pwmchip0/pwm0
+        SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
         echo 0 > $B/enable; echo 0 > $B/duty_cycle
         echo 3817000 > $B/period; echo 1526800 > $B/duty_cycle; echo 1 > $B/enable
         usleep 300000; echo 0 > $B/enable; usleep 100000
@@ -94,6 +95,8 @@ quit() {
         echo 0 > $B/duty_cycle
         echo 5714000 > $B/period; echo 2285600 > $B/duty_cycle; echo 1 > $B/enable
         usleep 600000; echo 0 > $B/enable
+        # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+        echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
     fi
 
     fb_restore
@@ -280,12 +283,15 @@ progress success
 
 if [ ! -f /useremain/rinkhals/.mute-sounds ]; then
     B=/sys/class/pwm/pwmchip0/pwm0
+    SAVED_P=$(cat $B/period 2>/dev/null); SAVED_D=$(cat $B/duty_cycle 2>/dev/null)
     echo 0 > $B/enable; echo 0 > $B/duty_cycle
     echo 2551000 > $B/period; echo 1020400 > $B/duty_cycle; echo 1 > $B/enable
     usleep 180000; echo 0 > $B/enable; usleep 50000
     echo 0 > $B/duty_cycle
     echo 1912000 > $B/period; echo 764800 > $B/duty_cycle; echo 1 > $B/enable
     usleep 280000; echo 0 > $B/enable
+    # Restore pwm0 to the state K3SysUi set so the touchscreen key sound keeps working
+    echo 0 > $B/duty_cycle; [ -n "$SAVED_P" ] && echo $SAVED_P > $B/period; [ -n "$SAVED_D" ] && echo $SAVED_D > $B/duty_cycle
 fi
 
 reboot


### PR DESCRIPTION
## Summary

Makes the "musical tones" leave `pwm0` in the same state the old `beep()` relied on, so the touchscreen Key Sound (and other stock/K3SysUi beeps that share the buzzer) keep working. Fixes the Discord reports that the latest test build silences touchscreen key beeps on the KS1.

## Root cause

The old buzzer helper only toggled `enable`, using whatever `period`/`duty_cycle` K3SysUi had already configured:

```sh
beep() {
    echo 1 > /sys/class/pwm/pwmchip0/pwm0/enable
    usleep $(($1 * 1000))
    echo 0 > /sys/class/pwm/pwmchip0/pwm0/enable
}
```

The musical-tones change (`6b771213`) had to write `period` and `duty_cycle` directly to produce different pitches, and left them changed. K3SysUi configures `pwm0`'s `period`/`duty_cycle` once for the Key Sound and only toggles `enable` per keypress (same pattern as the old `beep()`), so a reconfigured `pwm0` detunes or silences the key beeps until the next reboot. `ta_da` runs on every boot right after K3SysUi restarts, so it clobbers exactly the state K3SysUi just set.

## Fix

Every tone site now saves `pwm0`'s `period`/`duty_cycle` before playing and restores them afterward:
- `start.sh`: `ta_da` (startup success) and `quit` (startup failure)
- `update.sh`: success and failure tones
- the six tool-script jingles/failure tones (`backup-partitions`, `clean-rinkhals`, `config-reset`, `debug-bundle`, `factory-reset`, `rinkhals-uninstall`)

Pure additions (+33 lines, no deletions); the tones themselves are unchanged, so their pitch/timing is identical. Save/restore is inline rather than a shared helper because the tool scripts don't source `tools.sh` (and `config-reset`'s not-installed branch runs before Rinkhals exists).

## Testing

- `sh -n` clean on all 8 scripts.
- Verified on a KS1 that the save/restore round-trips `pwm0` exactly (period/duty return to baseline after a simulated tone).
- **Needs a hardware confirmation**: I can verify the `pwm0` state programmatically but not the audible key beep remotely. Someone on the test build should confirm Settings → General → Key Sound beeps are back after a normal boot, and after running a tool (e.g. debug bundle).

## Notes

Observed during testing that a KS1's `pwm0` sits at `period=1912000 duty=764800` — exactly `ta_da`'s final C5 note — consistent with a prior tone run leaving it there, which is the mechanism this fixes.
