### PR TITLE
fix(moonraker): normalize over-quoted SDCARD_PRINT_FILE filenames

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -519,6 +519,40 @@ class Kobra:
         logging.info(f'[Kobra] Normalized EXCLUDE_OBJECT name: {name} -> {normalized}')
         return script_new
 
+    def _normalize_print_file_script(self, script: str) -> str:
+        if not script:
+            return script
+
+        script_stripped = script.strip()
+        if not script_stripped.upper().startswith('SDCARD_PRINT_FILE'):
+            return script
+
+        # SDCARD_PRINT_FILE only takes FILENAME, so capture the rest of the
+        # line as the value (filenames may contain spaces).
+        match = re.match(r'(SDCARD_PRINT_FILE)\s+FILENAME=(.*)$', script_stripped, re.IGNORECASE | re.DOTALL)
+        if not match:
+            return script
+
+        cmd = match.group(1)
+        value = match.group(2).strip()
+
+        # Strip any number of balanced surrounding double-quote pairs. Some
+        # slicers (seen with OrcaSlicer 2.4.2) send the filename already
+        # wrapped in quotes, which Moonraker then wraps again, so GoKlipper
+        # receives FILENAME=""name"" and reads the leading "" as an empty
+        # value ("missing FILENAME"). A genuine escaped quote inside the name
+        # is left alone because the backslash breaks the pair test.
+        normalized = value
+        while len(normalized) >= 2 and normalized[0] == '"' and normalized[-1] == '"':
+            normalized = normalized[1:-1]
+
+        if normalized == value:
+            return script
+
+        script_new = f'{cmd} FILENAME="{normalized}"'
+        logging.info(f'[Kobra] Normalized SDCARD_PRINT_FILE filename quoting: {value} -> {normalized}')
+        return script_new
+
     def _normalize_exclude_object_status(self, exclude_status: dict, objects: List[dict]):
         if not isinstance(exclude_status, dict):
             return
@@ -1020,6 +1054,7 @@ class Kobra:
                     script = web_request.get_str('script', "")
                     if script:
                         normalized_script = self._normalize_exclude_object_script(script)
+                        normalized_script = self._normalize_print_file_script(normalized_script)
                         if normalized_script != script:
                             web_request.get_args()['script'] = normalized_script
                             script = normalized_script
@@ -1036,6 +1071,11 @@ class Kobra:
         def wrap_run_gcode(original_run_gcode: KlippyAPI.run_gcode):
             async def run_gcode(me: KlippyAPI, script: str, default: Any = Sentinel.MISSING):
                 logging.debug(f"hook on run gcode: {script}")
+
+                # Normalize here (before delegate captures script and before
+                # handle_gcode parses it) so both the delegated non-MQTT
+                # forward and the shlex-based FILENAME parse see a clean name.
+                script = self._normalize_print_file_script(script)
 
                 async def delegate_run_gcode():
                     return await original_run_gcode(me, script, default)


### PR DESCRIPTION
## Problem

Some users cannot start a print from OrcaSlicer. The print fails with:

```
Error on 'SDCARD_PRINT_FILE FILENAME=""test.gcode""': missing FILENAME
```

It reproduces with a plain filename (`test.gcode`, no spaces), via both `printer.print.start` and `printer.gcode.script`.

## Root cause

The filename reaches GoKlipper wrapped in **two** pairs of double quotes: `FILENAME=""test.gcode""`.

- OrcaSlicer 2.4.2 sends the filename already wrapped in quotes. Moonraker's `start_print` then applies the standard `SDCARD_PRINT_FILE FILENAME="{filename}"` wrap (or, on the `gcode.script` path, the client sends the whole quoted command), producing the doubled pair. Moonraker only ever writes one pair, so the extra pair comes from the client.
- Rinkhals forwards the command verbatim in the non-MQTT path, so the doubled quotes reach GoKlipper untouched.
- Lenient GoKlipper builds strip the quotes and print fine (confirmed on a Kobra S1, fw 2.7.2.7, by probing `/tmp/unix_uds1` directly). Stricter builds (Kobra S1 Max) read the leading `""` as an **empty** value and emit `Error on '%s': missing %s` (that format string lives in the gklib binary).

LAN-mode users never see this because prints take the MQTT path (`mqtt_print_file`), which uses the already-parsed clean filename. Only the non-MQTT SDCARD path is affected.

## Fix

Add `_normalize_print_file_script()`, mirroring the existing `_normalize_exclude_object_script()`. It strips any number of balanced surrounding double-quote pairs from the `FILENAME=` value and rebuilds a single clean `SDCARD_PRINT_FILE FILENAME="name"`. A genuinely escaped inner quote is preserved because the backslash breaks the pair test.

It is wired into both wrap layers:
- `wrap_request` (`gcode/script` endpoint) alongside the exclude-object normalization
- `wrap_run_gcode`, before the delegate captures `script` and before `handle_gcode` parses it, so both the non-MQTT forward and the shlex `FILENAME` parse see a clean name (this also fixes filenames with spaces, where a doubled pair otherwise shlex-splits into multiple tokens)

Defensive and idempotent: a normal single-quoted or bare filename is unchanged, and non-`SDCARD_PRINT_FILE` gcode is untouched.

## Testing

- Byte-compiles cleanly.
- Unit-checked the normalizer against: doubled, single, bare, doubled-with-spaces, single-with-spaces, genuinely-escaped-inner-quote, unrelated gcode, and a different handler (`EXCLUDE_OBJECT`). All produce the expected output.
- Verified against the live GoKlipper socket that a clean single-quoted command is accepted (fails only on file-not-found).

End-to-end validation on a non-MQTT Kobra S1 Max (the config that reproduces) is still wanted from the reporter on a test build.