### PR TITLE
fix(moonraker): Stop Fluidd freezing on MMU status updates

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -112,7 +112,7 @@ class Kobra:
 
     # GCode handlers
     gcode_handlers: dict[str, FlexCallback] = {}
-    status_patchers: List[Callable[[dict], dict]] = []
+    status_patchers: List[Callable[[dict, bool], dict]] = []
     print_data_patchers: List[Callable[[dict], dict]] = []
 
     def __init__(self, config):
@@ -860,6 +860,25 @@ class Kobra:
         setattr(KlippyAPI, 'send_status', wrap_send_status(KlippyAPI.send_status))
         logging.debug(f'  After: {KlippyAPI.send_status}')
 
+        # NOTE: ordering invariant for MMU status diffing (MmuAcePatcher.patch_status).
+        # patch_status() runs TWICE per GoKlipper status push: once here in
+        # the outer wrapper below, before delegating to the original
+        # handler, and again inside wrap_send_status's KlippyAPI.send_status
+        # above, since KlippyAPI is the host Subscribable that
+        # original__process_status_update fans the update out to for each
+        # connected client.
+        #
+        # The call in the outer wrapper below MUST run BEFORE delegating to
+        # original__process_status_update. That first call folds only the
+        # changed MMU keys into the shared `status` dict AND syncs the diff
+        # cache, so every subsequent send_status() call for each fanned-out
+        # subscriber sees an up-to-date cache (and correctly contributes no
+        # further changes), while still handing every subscriber the same
+        # already-patched `status` object. If this call were moved to run
+        # only inside send_status, or moved to after delegating here, only
+        # the first subscriber's send_status call would observe the diff
+        # and sync the cache -- every other subscriber in the same fan-out
+        # would silently receive a status frame with the MMU keys missing.
         def wrap__process_status_update(original__process_status_update):
             def _process_status_update(me, eventtime, status):
                 status = self.patch_status(status, is_subscription_update=True)
@@ -1436,6 +1455,27 @@ class Kobra:
         logging.debug(f'  Before: {KlippyConnection.request}')
         setattr(KlippyConnection, 'request', wrap_request(KlippyConnection.request))
         logging.debug(f'  After: {KlippyConnection.request}')
+
+        def wrap__request_standard(original__request_standard):
+            async def _request_standard(me, web_request, timeout=None):
+                args = web_request.get_args()
+
+                # gklib doesn't implement these, so never forward them.
+                # Unlike bed_mesh above, no synthesise-back is needed:
+                # patch_status merges mmu/mmu_machine onto every status.
+                if (self.is_goklipper_running() and
+                        isinstance(args, dict) and
+                        isinstance(args.get('objects'), dict) and
+                        web_request.get_endpoint() in ('objects/query', 'objects/subscribe')):
+                    args['objects'].pop('mmu', None)
+                    args['objects'].pop('mmu_machine', None)
+
+                return await original__request_standard(me, web_request, timeout)
+            return _request_standard
+
+        logging.debug(f'  Before: {KlippyConnection._request_standard}')
+        setattr(KlippyConnection, '_request_standard', wrap__request_standard(KlippyConnection._request_standard))
+        logging.debug(f'  After: {KlippyConnection._request_standard}')
 
     def patch_mainsail(self):
         from .klippy_connection import KlippyConnection

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -722,7 +722,7 @@ class Kobra:
         )
 
 
-    def patch_status(self, status):
+    def patch_status(self, status, is_subscription_update=False):
         if self.is_goklipper_running():
 
             if 'print_stats' in status:
@@ -818,14 +818,15 @@ class Kobra:
                     self._normalize_exclude_object_status(status['exclude_object'], objects)
 
         for patcher in self.status_patchers:
-            status = patcher(status)
+            status = patcher(status, is_subscription_update)
 
         if self.is_goklipper_running():
             self._maybe_force_end_excluded_object(status)
 
         return status
 
-    def register_status_patcher(self, patcher: Callable[[dict], dict]):
+    # patcher(status: dict, is_subscription_update: bool) -> dict
+    def register_status_patcher(self, patcher: Callable[[dict, bool], dict]):
         self.status_patchers.append(patcher)
 
     def register_print_data_patcher(self, patcher: Callable[[dict], dict]):
@@ -847,7 +848,7 @@ class Kobra:
 
         def wrap_send_status(original_send_status):
             def send_status(me, status, eventtime):
-                status = self.patch_status(status)
+                status = self.patch_status(status, is_subscription_update=True)
                 return original_send_status(me, status, eventtime)
             return send_status
 
@@ -861,7 +862,7 @@ class Kobra:
 
         def wrap__process_status_update(original__process_status_update):
             def _process_status_update(me, eventtime, status):
-                status = self.patch_status(status)
+                status = self.patch_status(status, is_subscription_update=True)
                 return original__process_status_update(me, eventtime, status)
             return _process_status_update
 
@@ -1374,7 +1375,9 @@ class Kobra:
                         "bed_mesh",
                         "bed_mesh default",
                         "bed_mesh \"default\"",
-                        "idle_timeout"
+                        "idle_timeout",
+                        "mmu",
+                        "mmu_machine"
                     ]
 
                     # For KS1M: Do not expose motion_report to avoid GoKlipper panic:

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -1575,6 +1575,9 @@ class MmuAcePatcher:
         # safely on the first call (reinit() runs during __init__).
         self._auto_feed_task = None
 
+        # Last mmu/mmu_machine status for diff push
+        self._last_pushed_mmu_status: dict = {}
+
         self.reinit()
 
         # mmu test enpoints
@@ -1588,7 +1591,7 @@ class MmuAcePatcher:
         self.server.register_endpoint("/server/filament_hub/set_fan_speed", ['POST'], self._handle_set_fan_speed)
 
         # mmu status update notification
-        self.server.register_notification("mmu_ace:status_update")
+        self.server.register_notification("mmu_ace:status_update", "mmu_ace_status_update")
 
         # gcode handlers
         self.register_gcode_handler("MMU_GATE_MAP", self._on_gcode_mmu_gate_map)
@@ -2382,13 +2385,21 @@ class MmuAcePatcher:
     def get_status(self) -> dict:
         return asdict(self.ace_controller.get_status())
 
-    def patch_status(self, status: dict):
+    def patch_status(self, status: dict, is_subscription_update: bool = False):
 
         mmu_status = self.get_status()
 
+        # return the full, current status
+        if not is_subscription_update:
+            for key, value in mmu_status.items():
+                status[key] = value
+            return status
+
+        # Subscription-update when changed
         for key, value in mmu_status.items():
-            status[key] = value
-        # status = self._combine(mmu_status, status)
+            if self._last_pushed_mmu_status.get(key) != value:
+                status[key] = value
+                self._last_pushed_mmu_status[key] = value
 
         return status
 

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -627,6 +627,11 @@ class MmuAceController:
 
         self._last_gate_fingerprint: str = ""
 
+        # Optional callback invoked at the end of _disable_ace(). Wired
+        # by MmuAcePatcher to also clear its subscription diff cache,
+        # since that cache lives on the patcher, not the controller.
+        self._on_ace_disabled: Optional[Callable[[], None]] = None
+
         # Start periodic cache cleanup task (runs every 60 seconds)
         # Removes expired temperature cache entries to prevent slow memory leak
         asyncio.create_task(self._periodic_cache_cleanup())
@@ -664,6 +669,9 @@ class MmuAceController:
         self._invalidate_gate_cache()
         self._last_gate_fingerprint = ""  # force status push on next _set_ace_status
         self._handle_status_update(force=True)
+
+        if self._on_ace_disabled is not None:
+            self._on_ace_disabled()
 
     def _handle_status_update(self, force: bool = False, throttle: bool = False):
         """Send status update notification with debouncing or throttling.
@@ -1567,6 +1575,7 @@ class MmuAcePatcher:
 
         host = config.get("host", None)
         self.ace_controller = MmuAceController(self.server, host)
+        self.ace_controller._on_ace_disabled = self._reset_mmu_status_cache
 
         # Tracks the single in-flight auto-feed poller (issue #464). patch_print_data
         # runs inside kobra.py's network retry loop, so without tracking, a retried
@@ -2358,6 +2367,11 @@ class MmuAcePatcher:
             self._auto_feed_task.cancel()
             self._auto_feed_task = None
 
+        # Clear the MMU status diff cache too, so the first push after a
+        # reinit forwards a full snapshot instead of diffing against
+        # values captured before the reset (see patch_status()).
+        self._reset_mmu_status_cache()
+
         self.ace = MmuAce()
         self.ace_controller.set_ace(self.ace)
 
@@ -2385,6 +2399,15 @@ class MmuAcePatcher:
     def get_status(self) -> dict:
         return asdict(self.ace_controller.get_status())
 
+    def _reset_mmu_status_cache(self):
+        """Clear the subscription diff cache (see patch_status()).
+        Called from reinit() and wired as MmuAceController's
+        ACE-disable callback so that whichever path resets ACE
+        state, the next status push forwards a full MMU snapshot
+        instead of comparing against values captured before the
+        reset."""
+        self._last_pushed_mmu_status = {}
+
     def patch_status(self, status: dict, is_subscription_update: bool = False):
 
         mmu_status = self.get_status()
@@ -2393,6 +2416,14 @@ class MmuAcePatcher:
         if not is_subscription_update:
             for key, value in mmu_status.items():
                 status[key] = value
+                # Keep the diff cache in sync even on the non-subscription
+                # (query) path. Without this, a query response can hand a
+                # client a value the subscription-diff cache never learns
+                # about; if the state later reverts, the next subscribed
+                # push compares against the stale pre-query cache, finds
+                # no difference, and the client is stuck showing the
+                # queried value indefinitely.
+                self._last_pushed_mmu_status[key] = value
             return status
 
         # Subscription-update when changed

--- a/tests/test_kobra.py
+++ b/tests/test_kobra.py
@@ -1,6 +1,7 @@
 import copy
 import importlib.util
 import sys
+import time
 import types
 import unittest
 from pathlib import Path
@@ -132,9 +133,33 @@ def _build_klippy_connection_module():
                 }
             return {"original": endpoint}
 
+        # patch_objects_list wraps _request_standard too (MMU stripping), so the
+        # fake must expose it even for tests that only exercise objects/list.
+        @staticmethod
+        async def _request_standard(me, web_request, timeout=None):
+            return {"status": {}}
+
+    class KlippyRequest:
+        @staticmethod
+        def set_result(me, result):
+            pass
+
     klippy_connection_module.KlippyConnection = KlippyConnection
+    klippy_connection_module.KlippyRequest = KlippyRequest
     sys.modules[KLIPPY_CONNECTION_NAME] = klippy_connection_module
     return klippy_connection_module
+
+
+class FakeObjectsWebRequest:
+    def __init__(self, endpoint: str, args: dict):
+        self._endpoint = endpoint
+        self._args = args
+
+    def get_endpoint(self):
+        return self._endpoint
+
+    def get_args(self):
+        return self._args
 
 
 def load_kobra_module():
@@ -333,6 +358,108 @@ class KobraObjectsListPatchTests(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertNotIn("chamber_temp", objects)
+
+
+class KobraMmuObjectStrippingTests(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_kobra_module()
+
+    def setUp(self):
+        self.klippy_connection_module = _build_klippy_connection_module()
+        self.kobra = self.module.Kobra.__new__(self.module.Kobra)
+        # Cache is valid for the next 100s, so is_goklipper_running()
+        # short-circuits on the cached PID without scanning /proc.
+        self.kobra._goklipper_next_check = time.time() + 100
+
+    async def _install_fake_and_patch(self, goklipper_pid):
+        self.kobra._goklipper_pid = goklipper_pid
+
+        captured = {}
+
+        async def fake_request_standard(me, web_request, timeout=None):
+            captured['objects'] = dict(web_request.get_args()['objects'])
+            return {"status": {}}
+
+        self.klippy_connection_module.KlippyConnection._request_standard = fake_request_standard
+        self.kobra.patch_objects_list()
+        return captured
+
+    async def test_mmu_and_mmu_machine_stripped_when_goklipper_running(self):
+        captured = await self._install_fake_and_patch(goklipper_pid=12345)
+
+        web_request = FakeObjectsWebRequest(
+            "objects/subscribe",
+            {"objects": {"mmu": None, "mmu_machine": None, "toolhead": None}},
+        )
+        result = await self.klippy_connection_module.KlippyConnection._request_standard(
+            None, web_request
+        )
+
+        self.assertNotIn('mmu', captured['objects'])
+        self.assertNotIn('mmu_machine', captured['objects'])
+        self.assertIn('toolhead', captured['objects'])
+        self.assertEqual(result, {"status": {}})
+
+    async def test_mmu_objects_not_stripped_when_goklipper_not_running(self):
+        captured = await self._install_fake_and_patch(goklipper_pid=None)
+
+        web_request = FakeObjectsWebRequest(
+            "objects/subscribe",
+            {"objects": {"mmu": None, "mmu_machine": None}},
+        )
+        await self.klippy_connection_module.KlippyConnection._request_standard(None, web_request)
+
+        self.assertIn('mmu', captured['objects'])
+        self.assertIn('mmu_machine', captured['objects'])
+
+    async def test_mmu_objects_not_stripped_for_unrelated_endpoint(self):
+        captured = await self._install_fake_and_patch(goklipper_pid=12345)
+
+        web_request = FakeObjectsWebRequest(
+            "some/other/endpoint",
+            {"objects": {"mmu": None}},
+        )
+        await self.klippy_connection_module.KlippyConnection._request_standard(None, web_request)
+
+        self.assertIn('mmu', captured['objects'])
+
+
+class KobraStatusPatcherTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_kobra_module()
+
+    def setUp(self):
+        self.kobra = self.module.Kobra.__new__(self.module.Kobra)
+        # Kobra.status_patchers is a mutable CLASS-level default list;
+        # shadow it with a fresh instance list so this test doesn't
+        # leak patchers into other tests/instances.
+        self.kobra.status_patchers = []
+
+    def test_registered_patcher_receives_status_and_is_subscription_update(self):
+        received = []
+
+        def patcher(status, is_subscription_update):
+            received.append((status, is_subscription_update))
+            return status
+
+        self.kobra.register_status_patcher(patcher)
+        self.kobra.patch_status({"foo": "bar"}, is_subscription_update=True)
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0][0], {"foo": "bar"})
+        self.assertIs(received[0][1], True)
+
+    def test_patch_status_defaults_is_subscription_update_to_false(self):
+        received = []
+        self.kobra.register_status_patcher(
+            lambda status, is_sub: (received.append(is_sub), status)[1]
+        )
+
+        self.kobra.patch_status({})
+
+        self.assertEqual(received, [False])
 
 
 if __name__ == "__main__":

--- a/tests/test_mmu_ace.py
+++ b/tests/test_mmu_ace.py
@@ -166,6 +166,18 @@ class MmuAceControllerSyncTests(unittest.TestCase):
         self.assertEqual(status.mmu.filament_pos, self.module.FILAMENT_POS_UNLOADED)
         self.assertTrue(status.mmu.active_filament.empty)
 
+    def test_disable_ace_invokes_registered_reset_callback(self):
+        calls = []
+        self.controller._on_ace_disabled = lambda: calls.append(True)
+
+        self.controller._disable_ace("test reason")
+
+        self.assertEqual(calls, [True])
+
+    def test_disable_ace_without_callback_does_not_raise(self):
+        self.controller._on_ace_disabled = None
+        self.controller._disable_ace("test reason")  # must not raise
+
 
 class MmuAcePartialUpdateTests(unittest.IsolatedAsyncioTestCase):
     @classmethod
@@ -390,6 +402,73 @@ class MmuRecoverTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(refresh_calls, [{"force": True}])
         self.assertEqual(len(responses), 1)
         self.assertIn("ACE status refreshed", responses[0])
+
+
+class MmuAcePatchStatusTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_mmu_ace_module()
+
+    def _make_patcher(self, mmu_status):
+        patcher = self.module.MmuAcePatcher.__new__(self.module.MmuAcePatcher)
+        patcher._last_pushed_mmu_status = {}
+        patcher.get_status = lambda: mmu_status
+        return patcher
+
+    def test_non_subscription_returns_full_snapshot_and_updates_cache(self):
+        patcher = self._make_patcher({"mmu": {"gate": 1}, "mmu_machine": {"num_units": 1}})
+
+        status = patcher.patch_status({}, is_subscription_update=False)
+
+        self.assertEqual(status, {"mmu": {"gate": 1}, "mmu_machine": {"num_units": 1}})
+        # Regression check for the lost-update hole: the non-subscription
+        # path must also populate the diff cache.
+        self.assertEqual(
+            patcher._last_pushed_mmu_status,
+            {"mmu": {"gate": 1}, "mmu_machine": {"num_units": 1}},
+        )
+
+    def test_subscription_suppresses_unchanged_and_emits_changed(self):
+        patcher = self._make_patcher({"mmu": {"gate": 1}, "mmu_machine": {"num_units": 1}})
+        patcher._last_pushed_mmu_status = {"mmu": {"gate": 0}, "mmu_machine": {"num_units": 1}}
+
+        status = patcher.patch_status({}, is_subscription_update=True)
+
+        self.assertEqual(status, {"mmu": {"gate": 1}})
+        self.assertEqual(
+            patcher._last_pushed_mmu_status,
+            {"mmu": {"gate": 1}, "mmu_machine": {"num_units": 1}},
+        )
+
+    def test_query_between_subscription_pushes_does_not_leave_stale_cache(self):
+        """Reproduces the review's lost-update scenario: baseline X,
+        MMU changes to Y, a client queries and is served Y, MMU
+        reverts to X -- the next subscribed push must still emit the
+        reverted value X instead of finding a false non-diff."""
+        patcher = self._make_patcher({"mmu": {"gate": 0}})
+
+        # Baseline subscribed push (X).
+        patcher.patch_status({}, is_subscription_update=True)
+
+        # MMU changes to Y; a client issues a query (non-subscription).
+        patcher.get_status = lambda: {"mmu": {"gate": 1}}
+        patcher.patch_status({}, is_subscription_update=False)
+
+        # MMU reverts to X; the next subscribed push must not be empty.
+        patcher.get_status = lambda: {"mmu": {"gate": 0}}
+        status = patcher.patch_status({}, is_subscription_update=True)
+
+        self.assertEqual(status, {"mmu": {"gate": 0}})
+
+    def test_reinit_resets_mmu_status_cache(self):
+        patcher = self.module.MmuAcePatcher.__new__(self.module.MmuAcePatcher)
+        patcher._auto_feed_task = None
+        patcher._last_pushed_mmu_status = {"mmu": {"gate": 5}}
+        patcher.ace_controller = types.SimpleNamespace(set_ace=lambda ace: None)
+
+        patcher.reinit()
+
+        self.assertEqual(patcher._last_pushed_mmu_status, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes two bugs that broke Fluidd's live status updates for the MMU integration on Kobra S1 Max: a notification-name collision that silently froze the entire Fluidd UI after any MMU gate change and a missing `objects/list` entry that kept the gate/spool display from updating. 
Fixes also how the update status of the mmu is handled (diff or full) since fixing those two bug introduced a new problem  - user unable to edit filaments in Fluidd - that was not visible before.

## Why

Clicking an MMU gate tile (or spools icon) in Fluidd would eventually freeze all live updates (thermals, print status) with no error anywhere. Separately, `MMU_SELECT` changes weren't reflected in the gate/spool display even though the command succeeded server-side.

## Changes

- `mmu_ace.py`: give `mmu_ace:status_update` an explicit `notify_name` — the derived name collided with Klipper's own `notify_status_update`, due to how Moonraker is shortening the names. When `register_notification()` is called without an explicit `notify_name`, Moonraker derives one by taking everything after the last colon in the event name (`event_name.split(':')[-1]`), then prefixes it with `notify_` to build the actual method sent so it become `"notify_status_update"`. That's the exact same wire method Moonraker's own core status-update push already uses for every subscribed printer object (temperatures, print state, etc.) 
- `kobra.py`: add `mmu`/`mmu_machine` to the hardcoded `objects/list` response - Fluidd builds its subscription from this list, so without the entry it never subscribed to MMU status at all.
- `kobra.py`, `mmu_ace.py`: edit `patch_status` add `is_subscription_update` which push full or diff status update depending on the subscription - this fix the issue with edit filaments in Fluidd where user was unable to edit filaments data due to constant full refresh

## Testing

Kobra S1 Max, firmware `2.7.1.4`, Rinkhals build `20260711_01_test`.

- [x] Existing tests in `tests/` still pass
- [x] Manually tested on a real printer 
   - reproduced both bugs, 
   - verified each fix independently (reverted/retested separately), 
   - confirmed combined fix resolves both
   - tested mainsail - worked before and after test - no impact
- [ ] Documentation updated — n/a, no user-facing behaviour changed

## Related issues

Fixes #
Related to #

## Notes for reviewers
