### PR TITLE
fix(apps): detach backgrounded daemons' fds so the touch UI can't hang

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/app.sh
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/app.sh
@@ -17,7 +17,13 @@ start() {
     cd $APP_ROOT
 
     chmod +x moonraker.sh
-    ./moonraker.sh &
+    # Detach stdin/stdout/stderr from /dev/null. moonraker.sh stays resident
+    # (its restart loop waits on Moonraker), so if it inherited this shell's
+    # fds it would hold them open. When start is invoked from the on-screen
+    # menu (rinkhals-ui.py), which captures the command's output through a
+    # pipe, that keeps the pipe's write end open and hangs the UI (a frozen
+    # touchscreen). moonraker.sh writes everything to app-moonraker.log.
+    ./moonraker.sh </dev/null >/dev/null 2>&1 &
 }
 debug() {
     stop

--- a/files/4-apps/home/rinkhals/apps/60-firmware-collector/app.sh
+++ b/files/4-apps/home/rinkhals/apps/60-firmware-collector/app.sh
@@ -31,13 +31,20 @@ start() {
     # supervisor.sh owns scheduling and stays resident (a few hundred KB while
     # it sleeps) instead of a ~14 MB Python daemon. It spawns collector.py for
     # each check, which runs ~20s and exits, freeing its memory.
+    #
+    # Detach stdin/stdout/stderr from /dev/null. supervisor.sh is long-lived,
+    # so if it inherited this shell's fds it would keep them open for hours.
+    # When start is invoked from the on-screen menu (rinkhals-ui.py), which
+    # captures the command's output through a pipe, that would leave the pipe's
+    # write end open and hang the UI (a frozen touchscreen) until the app is
+    # stopped. supervisor.sh sends its own output to app-firmware-collector.log.
     INGEST_ENDPOINT="$INGEST_ENDPOINT" \
     INTERVAL_HOURS="$INTERVAL_HOURS" \
     DRY_RUN="$DRY_RUN" \
     KOBRA_MODEL_CODE="$KOBRA_MODEL_CODE" \
     RINKHALS_VERSION="$RINKHALS_VERSION" \
     RINKHALS_LOGS="$RINKHALS_LOGS" \
-        $APP_ROOT/supervisor.sh &
+        $APP_ROOT/supervisor.sh </dev/null >/dev/null 2>&1 &
 
     echo $! > "$PIDFILE"
 }


### PR DESCRIPTION
## Symptom

Enabling the **Firmware Collector** from the printer's on-screen Rinkhals menu freezes the touchscreen (reported and reproduced on a Kobra S1 running `20260716_01`). A reboot recovers it, but re-enabling freezes it again.

## Root cause

The on-screen menu (`rinkhals-ui.py`) starts an app by running `app.sh start` and reading the command's stdout through a pipe until EOF. Two apps background a **long-lived** process without redirecting its fds:

- `60-firmware-collector`: `supervisor.sh &` (sleeps between checks for hours)
- `40-moonraker`: `./moonraker.sh &` (restart loop `wait`s on Moonraker)

The backgrounded process inherits `app.sh`'s stdout, which is the UI's capture pipe, and holds the pipe's **write end** open for the app's entire lifetime. The UI's read never sees EOF, so the menu thread blocks and the display freezes until the app is stopped.

Confirmed live via `/proc`: the UI process held the read ends of pipes `16801`/`16802`, and the backgrounded `supervisor.sh` held the matching write ends on its fd 1 and 2.

Moonraker has the same latent defect but never triggers it in practice because it is started at boot by the app-monitor, not toggled from the touchscreen. The collector is the app users newly enable from the screen.

## Fix

Redirect both backgrounded processes' stdin/stdout/stderr to `/dev/null`, matching the pattern already used by mainsail, fluidd, mjpg-streamer, rinkhals-web, remote-display and hostname-dns. Their real output already goes to their own log files (`app-firmware-collector.log`, `app-moonraker.log`), so nothing is lost.

## Verification (on hardware, KS1 / 20260716_01)

- Before: `app.sh start` invoked through a capturing pipe never returns.
- After: it returns in ~1s (rc=0), the caller gets the finite startup log and EOF, and the supervisor holds `/dev/null` on fds 0/1/2.

## Notes

- This is a regression in the shipped stable `20260716_01` (the collector was refactored to the `supervisor.sh` one-shot model in that cycle). Worth considering a patch release.
- Follow-up worth discussing: a systemic guard so a future app can't reintroduce this, e.g. have `start_app` / the UI invoke `app.sh start` with a bounded read or detached stdout rather than relying on every app to redirect. Out of scope for this fix.