### PR TITLE
fix(web-portal): disabling an app now stops it (and enabling starts it)

### DIFF
--- a/files/4-apps/home/rinkhals/apps/65-rinkhals-web/apps.go
+++ b/files/4-apps/home/rinkhals/apps/65-rinkhals-web/apps.go
@@ -449,10 +449,20 @@ func handleApp(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(resp)
 
 	case sub == "enable" && r.Method == "POST":
-		runAppHelper(w, "enable_app", id)
+		// Enable is imperative: flip the flag AND start the app now. The
+		// start.sh app loop only reconciles enabled/disabled state at boot,
+		// so without starting here the app would not run until a reboot.
+		// Mirrors the catalog install path (enable_app && start_app).
+		q := shellQuote(id)
+		runAppCmd(w, fmt.Sprintf("enable_app %s && start_app %s", q, q))
 
 	case sub == "disable" && r.Method == "POST":
-		runAppHelper(w, "disable_app", id)
+		// Disable is imperative: flip the flag AND stop the running process
+		// now. disable_app only clears the flag; nothing reconciles at
+		// runtime, so a disabled app would otherwise keep running (and
+		// holding its RAM) until the next reboot.
+		q := shellQuote(id)
+		runAppCmd(w, fmt.Sprintf("disable_app %s && stop_app %s", q, q))
 
 	case sub == "action" && r.Method == "POST":
 		var req struct {


### PR DESCRIPTION
## Symptom

Disabling an app in the WebUI (reported for **Remote Display**, toggled off to save RAM) leaves its process running. `is_app_enabled` returns 0, but the process keeps running and holding its memory until the next reboot.

## Root cause

The WebUI `/enable` and `/disable` endpoints (`apps.go`) only flip the enabled flag via `enable_app` / `disable_app`. Those helpers do not touch the running process. Nothing reconciles app state at runtime either: the loop in `start.sh` that stops a disabled-but-running app (and starts an enabled-but-stopped one) only runs **at boot**.

So at runtime, disabling flips the flag but never stops the process. Confirmed live: `is_app_enabled 50-remote-display => 0` while `drm-vncserver` (PID 1211) was still running.

The catalog install path already does the right thing (`enable_app && start_app`, catalog.go:545); the toggle endpoints were the inconsistent ones.

## Fix

Make both endpoints imperative, so the WebUI action takes effect immediately and matches the boot-loop intent:

- `enable`  -> `enable_app %s && start_app %s`
- `disable` -> `disable_app %s && stop_app %s`

`start_app` is bounded by its own `timeout -t` guard (and self-stops on timeout); `stop_app` runs `app.sh stop`.

## Verification

- Builds locally (`go build ./...`).
- Command strings validated on hardware (KS1, 20260716_02): `enable_app && start_app` -> app running; `disable_app && stop_app` -> process gone, flag cleared, RAM freed.

## Note

Same class of issue as the recent boot-loop/one-shot work: runtime state changes must be imperative because there is no continuous reconciler, only the boot pass. If a continuous monitor is ever added, these could revert to flag-only, but imperative is correct today.