### PR TITLE
fix(web-portal): System Logs Rinkhals tab points at the live log

### DIFF
--- a/web-portal/src/routes/logs/+page.svelte
+++ b/web-portal/src/routes/logs/+page.svelte
@@ -7,13 +7,17 @@
     let autoScroll = $state(true);
     let logContainer: HTMLElement;
 
-    let activeLog = $state('/useremain/rinkhals/rinkhals.log');
-    // gklib and gkapi write their live logs to /tmp (tmpfs) under Rinkhals; the
-    // /useremain/log/*.log copies are the stock Anycubic files and go stale once
-    // Rinkhals takes over. Moonraker's path is the bind-mounted printer_data log
-    // it actively writes. Rinkhals is the persistent boot log.
+    let activeLog = $state('/tmp/rinkhals/rinkhals.log');
+    // These are the live logs the running processes actually write, all under
+    // RINKHALS_LOGS=/tmp/rinkhals (tmpfs) except Moonraker:
+    //  - Rinkhals: tools.sh log() appends to /tmp/rinkhals/rinkhals.log for the
+    //    whole session. (/useremain/rinkhals/rinkhals.log is only the early boot
+    //    loader stub, written before tools.sh and then frozen, so it goes stale.)
+    //  - gklib/gkapi: live logs in /tmp; the /useremain/log/*.log copies are the
+    //    stock Anycubic files and go stale once Rinkhals takes over.
+    //  - Moonraker: the bind-mounted printer_data log it actively writes.
     const logFiles = [
-        { name: "Rinkhals", path: "/useremain/rinkhals/rinkhals.log" },
+        { name: "Rinkhals", path: "/tmp/rinkhals/rinkhals.log" },
         { name: "Klipper (gklib)", path: "/tmp/gklib.log" },
         { name: "Moonraker", path: "/useremain/home/rinkhals/printer_data/logs/moonraker.log" },
         { name: "GKAPI", path: "/tmp/gkapi.log" }


### PR DESCRIPTION
## Audit

Prompted by the question "are the System Logs sources actually the live logs?" I checked all four sources on hardware (KS1, `20260716_02`):

| Source | WebUI path | Verdict |
|---|---|---|
| Klipper (gklib) | `/tmp/gklib.log` | Live (already fixed) |
| GKAPI | `/tmp/gkapi.log` | Live (already fixed) |
| Moonraker | `/useremain/home/rinkhals/printer_data/logs/moonraker.log` | Live (same inode `209685` as the bind-mounted `/userdata/app/gk/printer_data/logs/moonraker.log`) |
| **Rinkhals** | `/useremain/rinkhals/rinkhals.log` | **Stale** |

## The bug

The Rinkhals source (and the default selection) pointed at `/useremain/rinkhals/rinkhals.log`, which is only the early boot **loader stub**: it is written before `tools.sh` is sourced and then frozen. On the printer its last lines were:

```
Thu Jan  1 08:00:22 CST 1970: Rinkhals version 20260716_02 selected
```

(pre-NTP 1970 clock, boot-time). Tailing it in the viewer shows nothing new, ever.

The live Rinkhals log is `/tmp/rinkhals/rinkhals.log`: `tools.sh` sets `RINKHALS_LOGS=/tmp/rinkhals` and `log()` appends there for the whole session. On the same printer its tail had current, timestamped entries (`[2026-07-16 21:24:05]: Killing ... drm-vncserver`).

## Fix

Point the Rinkhals source and the default at `/tmp/rinkhals/rinkhals.log`, matching gklib/gkapi which already read their live `/tmp` logs. Comment updated to explain the distinction.

## Note

The stale `/useremain/rinkhals/rinkhals.log` boot stub does have some value for diagnosing a boot that never reaches `tools.sh` logging. If wanted, it could be added back as a separate "Rinkhals (boot loader)" tab, but that is out of scope here; the live runtime log is what the primary tab should show.