### PR TITLE
fix(app-store): show the installable version and add TouchUI updates

### DIFF
--- a/files/3-rinkhals/opt/rinkhals/ui/rinkhals-ui.py
+++ b/files/3-rinkhals/opt/rinkhals/ui/rinkhals-ui.py
@@ -1300,6 +1300,33 @@ class RinkhalsUiApp(BaseApp):
             self.modal_store_install.button_done.add_flag(lv.OBJ_FLAG.HIDDEN)
             self.modal_store_install.button_done.add_event_cb(lambda e: self.hide_modal(), lv.EVENT_CODE.CLICKED, None)
 
+    def fetch_store_manifest(self, app_dir, ref, api_headers):
+        # Read the manifest at the release tag first so the version we show is
+        # the one bundled in the installable SWU. Apps added after the release
+        # won't exist at the tag, so fall back to the branch for display.
+        import requests
+        refs = [ref] + ([self.APP_STORE_BRANCH] if ref != self.APP_STORE_BRANCH else [])
+        for r in refs:
+            try:
+                url = f'https://raw.githubusercontent.com/{self.APP_STORE_REPO}/{r}/apps/{app_dir}/app.json'
+                resp = requests.get(url, headers=api_headers, timeout=5)
+                if resp.status_code == 200:
+                    return json.loads(resp.text, cls=JSONWithCommentsDecoder)
+            except Exception:
+                pass
+        return {}
+
+    def installed_app_version(self, app_dir):
+        # Returns (version, is_installed) for a locally installed app.
+        path = f'{RINKHALS_HOME}/apps/{app_dir}/app.json'
+        if not os.path.exists(path):
+            return '', False
+        try:
+            with open(path) as f:
+                return (json.load(f, cls=JSONWithCommentsDecoder).get('version') or ''), True
+        except Exception:
+            return '', True
+
     def show_app_store(self):
         if self.screen_store.panel_apps:
             self.screen_store.panel_apps.delete()
@@ -1329,6 +1356,17 @@ class RinkhalsUiApp(BaseApp):
                 entries = response.json()
                 app_dirs = [e for e in entries if e.get('type') == 'dir']
 
+                # Resolve the latest release tag and read manifests from it, so
+                # the versions shown match the SWUs that will install (branch
+                # HEAD can be ahead of the released build).
+                manifest_ref = self.APP_STORE_BRANCH
+                try:
+                    rel_resp = requests.get(f'https://api.github.com/repos/{self.APP_STORE_REPO}/releases/latest', headers=api_headers, timeout=10)
+                    if rel_resp.status_code == 200:
+                        manifest_ref = rel_resp.json().get('tag_name') or self.APP_STORE_BRANCH
+                except Exception:
+                    pass
+
                 with lvr.lock():
                     label_loading.add_flag(lv.OBJ_FLAG.HIDDEN)
 
@@ -1337,19 +1375,12 @@ class RinkhalsUiApp(BaseApp):
                     if not app_dir:
                         continue
 
-                    manifest_url = f'https://raw.githubusercontent.com/{self.APP_STORE_REPO}/{self.APP_STORE_BRANCH}/apps/{app_dir}/app.json'
-                    try:
-                        manifest_response = requests.get(manifest_url, headers=api_headers, timeout=5)
-                        if manifest_response.status_code == 200:
-                            app_manifest = json.loads(manifest_response.text, cls=JSONWithCommentsDecoder)
-                        else:
-                            app_manifest = {}
-                    except Exception:
-                        app_manifest = {}
+                    app_manifest = self.fetch_store_manifest(app_dir, manifest_ref, api_headers)
 
                     app_name = app_manifest.get('name') or app_dir
                     app_version = app_manifest.get('version') or ''
-                    is_installed = os.path.exists(f'{RINKHALS_HOME}/apps/{app_dir}/app.json')
+                    installed_version, is_installed = self.installed_app_version(app_dir)
+                    update_available = bool(is_installed and installed_version and app_version and installed_version != app_version)
 
                     with lvr.lock():
                         panel_app = lvr.panel(self.screen_store.panel_apps)
@@ -1372,7 +1403,7 @@ class RinkhalsUiApp(BaseApp):
                             label_installed = lvr.subtitle(panel_app)
                             label_installed.set_align(lv.ALIGN.RIGHT_MID)
                             label_installed.set_style_text_color(lvr.COLOR_PRIMARY, lv.STATE.DEFAULT)
-                            label_installed.set_text('Installed')
+                            label_installed.set_text('Update' if update_available else 'Installed')
 
             except Exception as ex:
                 logging.error(f'App store fetch failed: {ex}')
@@ -1387,15 +1418,29 @@ class RinkhalsUiApp(BaseApp):
         app_name = app_manifest.get('name') or app_dir
         app_version = app_manifest.get('version') or ''
         app_description = app_manifest.get('description') or ''
-        is_installed = os.path.exists(f'{RINKHALS_HOME}/apps/{app_dir}/app.json')
+        installed_version, is_installed = self.installed_app_version(app_dir)
+        update_available = bool(is_installed and installed_version and app_version and installed_version != app_version)
 
         self.screen_store_app.label_title.set_text(ellipsis(app_name, 24))
-        self.screen_store_app.label_version.set_text(f'Version: {app_version}' if app_version else '')
+        if update_available:
+            self.screen_store_app.label_version.set_text(f'Version: {installed_version} -> {app_version}')
+        else:
+            self.screen_store_app.label_version.set_text(f'Version: {app_version}' if app_version else '')
         self.screen_store_app.label_description.set_text(app_description)
 
         self.screen_store_app.button_action.clear_event_cb()
 
-        if is_installed:
+        if update_available:
+            # Single action button, so Update takes priority over Remove while an
+            # update is pending. Reinstalling the SWU upgrades in place; the
+            # button reverts to Remove once installed == available.
+            self.screen_store_app.button_action.set_text('Update')
+            self.screen_store_app.button_action.set_style_text_color(lvr.COLOR_PRIMARY, lv.STATE.DEFAULT)
+            self.screen_store_app.button_action.add_event_cb(
+                lambda e, d=app_dir, n=app_name: self.install_store_app(d, n),
+                lv.EVENT_CODE.CLICKED, None
+            )
+        elif is_installed:
             self.screen_store_app.button_action.set_text('Remove')
             self.screen_store_app.button_action.set_style_text_color(lvr.COLOR_DANGER, lv.STATE.DEFAULT)
             self.screen_store_app.button_action.add_event_cb(

--- a/files/4-apps/home/rinkhals/apps/65-rinkhals-web/catalog.go
+++ b/files/4-apps/home/rinkhals/apps/65-rinkhals-web/catalog.go
@@ -198,10 +198,14 @@ type ghRelease struct {
 	Assets  []ghReleaseAsset `json:"assets"`
 }
 
-// fetchManifest pulls apps/<name>/app.json from raw.githubusercontent.com.
+// fetchManifest pulls apps/<name>/app.json from raw.githubusercontent.com at
+// the given git ref (branch or tag). Empty ref falls back to catalogBranch.
 // raw isn't rate-limited so we hammer it freely.
-func fetchManifest(appName string) (*AppManifest, error) {
-	url := fmt.Sprintf("%s/%s/apps/%s/app.json", catalogRawBase, catalogBranch, appName)
+func fetchManifest(appName, ref string) (*AppManifest, error) {
+	if ref == "" {
+		ref = catalogBranch
+	}
+	url := fmt.Sprintf("%s/%s/apps/%s/app.json", catalogRawBase, ref, appName)
 	var m AppManifest
 	if err := httpGetJSON(url, &m); err != nil {
 		return nil, err
@@ -312,7 +316,15 @@ func rebuildCatalog() (*Catalog, error) {
 		if e.Type != "dir" {
 			continue
 		}
-		m, err := fetchManifest(e.Name)
+		// Read the manifest from the same point the installable SWU was built
+		// (the latest release tag) so the displayed version matches what will
+		// actually install. Apps with no release asset for this model are not
+		// installable, so they fall back to the branch HEAD manifest for display.
+		ref := catalogBranch
+		if _, ok := assetByApp[e.Name]; ok && rel.TagName != "" {
+			ref = rel.TagName
+		}
+		m, err := fetchManifest(e.Name, ref)
 		if err != nil {
 			// One bad manifest shouldn't take down the catalog; surface a stub.
 			apps = append(apps, CatalogApp{


### PR DESCRIPTION
## Report

A user on nfs-mount v0.1 saw the App Store show **v0.2**, but installing gave **v0.1**. Also: the web App Store has an Update button, the TouchUI doesn't (only Remove).

## Root cause

The App Store reads the *displayed version* and the *installable SWU* from two different places:

- **Displayed version** = `apps/<name>/app.json` on the Rinkhals.Apps **`master` branch** (HEAD).
- **Installed SWU** = the `app-<name>-<group>.swu` asset from the **latest Rinkhals.Apps release**.

When a manifest is bumped on `master` but no new release is cut, these drift and the store advertises a version it cannot install. Confirmed live for nfs-mount:

- `master` manifest: `"version": "0.2"` (bumped 2026-06-27)
- latest release `20260531_01` (May 31): its `app-nfs-mount-*.swu` is still 0.1 (manifest **at that tag** = `0.1`)

Both UIs had this, in separate code: `catalog.go` (web) and `rinkhals-ui.py` (TouchUI, its own direct-GitHub catalog).

## Fixes

**1. Show the installable version (both UIs).** Read the displayed manifest from the **latest release tag** (the point the SWU was built from) instead of `master` HEAD, so shown version == installed version. Apps with no release asset for the model fall back to the branch manifest (they aren't installable from the release anyway, so no mismatch).

**2. TouchUI updates.** With shown == installed now consistent, the TouchUI App Store compares the installed manifest version to the available one and offers **Update** when they differ:
- list shows `Update` instead of `Installed`
- detail screen shows `v<installed> -> v<available>` and the action button becomes `Update` (reinstalls the SWU in place), reverting to `Remove` once up to date

The TouchUI detail screen has a single action button, so Update takes priority over Remove while an update is pending (Remove returns after updating). The web UI already had update detection.

## Important: this is not a complete fix on its own

The code now makes the store **honest** about what is installable. For a bumped app (like nfs-mount 0.2) to actually become updatable, **a new Rinkhals.Apps release must be cut** so the newer SWU exists. Until then the store correctly shows the released version (0.1) rather than a phantom 0.2 update. That release is a separate action in the `Rinkhals.Apps` repo.

## Verification

- `go build ./...` passes.
- `rinkhals-ui.py` byte-compiles under the printer's Python 3.11.6 (and locally).
- Verified against live GitHub that the manifest at release tag `20260531_01` resolves to nfs-mount `0.1`, matching the installed SWU.
- On-hardware TouchUI interaction (open App Store, see version + Update button) still to be exercised on a test build.