### PR TITLE
chore(ci): target Dependabot at develop and add PR checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Dependabot had no config at all, so it fell back to the repository default
+# branch (master) and opened every update against it. master is release-only
+# here - everything lands on develop first - so those PRs all had to be
+# retargeted by hand before they could be merged. target-branch fixes that.
+updates:
+  # Web portal frontend. Its build output is bundled into the firmware image
+  # shipped to printers, so runtime dependency updates here reach real devices.
+  - package-ecosystem: npm
+    directory: /web-portal
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # These share package-lock.json, so separate PRs conflict with each other
+      # and have to be merged one at a time with a rebase in between. Grouping
+      # the routine ones keeps that to a single lockfile change.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Major bumps here have meant a bundler swap (vite 7 -> 8 moved us from
+      # rollup+esbuild to rolldown), which changes the JavaScript we ship and
+      # needs a deliberate decision plus a build and browser test. Security
+      # updates are unaffected by ignore rules and still come through.
+      - dependency-name: vite
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@sveltejs/vite-plugin-svelte"
+        update-types:
+          - version-update:semver-major
+
+  # Go backend for the web portal.
+  - package-ecosystem: gomod
+    directory: /files/4-apps/home/rinkhals/apps/65-rinkhals-web
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+
+  # Actions used by the release and docs workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,75 @@
+name: PR checks
+
+# Nothing ran on pull requests before this: build-swu and develop-test-build are
+# workflow_dispatch, auto-release is push-on-tag, gh-pages-deploy is push-to-master.
+# So dependency bumps that break the frontend build or the Python components were
+# only discovered at release time, when the Docker image build failed.
+#
+# These are the two cheap checks that would have caught that, and nothing more -
+# no SWU build here, since that needs the ARM toolchain and takes far too long
+# for a PR gate.
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  web-portal:
+    name: Web portal builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect web-portal changes
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -q '^web-portal/'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Keep in step with the Dockerfile's build-web-ui stage (node:22-bookworm).
+      - uses: actions/setup-node@v4
+        if: steps.changed.outputs.run == 'true'
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: web-portal/package-lock.json
+
+      - name: npm ci
+        if: steps.changed.outputs.run == 'true'
+        working-directory: web-portal
+        run: npm ci
+
+      - name: npm run build
+        if: steps.changed.outputs.run == 'true'
+        working-directory: web-portal
+        run: npm run build
+
+  python-tests:
+    name: Python component tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pytest
+        run: python -m pip install --quiet pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -q


### PR DESCRIPTION
Two gaps found while reviewing the open PRs. Both are causes, not symptoms.

## 1. Dependabot had no config, so it targeted `master`

There is no `.github/dependabot.yml` on any branch (verified with `git log --all`). Dependabot therefore fell back to the repository default branch, which is `master`. That is why **all four** open bumps (#77, #79, #80, #90) arrived targeting the release-only branch and had to be retargeted by hand before they could be merged.

Adds a config with `target-branch: develop` for npm (`/web-portal`), gomod (the web portal's Go backend) and github-actions.

Two deliberate choices in the npm entry:

- **Grouped dev-dependency minor/patch updates.** All of these edit `web-portal/package-lock.json`, so separate PRs conflict with one another and must be merged one at a time with a rebase in between - exactly what happened this round. Grouping keeps routine churn to a single lockfile change.
- **Major bumps of `vite` and `@sveltejs/vite-plugin-svelte` are ignored.** #80 is the reason: presented as `chore(deps-dev)`, it is actually vite 7→8 plus plugin 6→7, which **swaps the bundler from rollup+esbuild to rolldown** (54 packages removed, 30 added) and quietly carries a `@tailwindcss/vite` bump. That changes the JavaScript we ship inside the firmware image and deserves a deliberate decision. Note ignore rules do **not** suppress security updates, which still come through.

## 2. Nothing ran on pull requests

Confirmed across all four existing workflows: `build-swu` and `develop-test-build` are `workflow_dispatch`, `auto-release` is push-on-tag, `gh-pages-deploy` is push-to-master. `statusCheckRollup` was empty on every open PR - their `BLOCKED` state is `REVIEW_REQUIRED`, not a failing check.

So `npm ci && npm run build` had **never run** on any of the four dependency PRs. A bump that breaks the frontend would only surface at release time, when the Docker image build fails.

Adds a `pull_request` workflow with two cheap jobs:
- **web-portal** - `npm ci` + `npm run build`, skipped unless `web-portal/` actually changed. Node 22 to match the Dockerfile's `build-web-ui` stage.
- **python-tests** - the existing `pytest tests/ -q` suite (28 tests).

Deliberately **not** building the SWU here: that needs the ARM toolchain and is far too slow for a PR gate.

## Verification

Both files parse as valid YAML. I also ran the frontend build locally against the just-merged develop (dompurify 3.4.12, kit 2.69.3, svelte 5.56.5) and it succeeds - so this workflow should be green on arrival rather than landing red.