### PR TITLE
Expose chamber heater and remaining fans to web UIs on Kobra S1 / S1 Max

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -1388,6 +1388,21 @@ class Kobra:
                         objects.append("fan_generic air_filter_fan")
                         objects.append("fan_generic box_fan")
 
+                        # The chamber heater is a first-class GoKlipper heater on the S1 family
+                        # ([chamber_temp] in the stock printer.cfg, PID controlled, max_temp 65),
+                        # and it is already reported in heaters.available_heaters. It was simply
+                        # never added to this list, so Mainsail/Fluidd never subscribed to it and
+                        # users had no chamber temperature readout or setpoint in the web UI.
+                        objects.append("chamber_temp")
+
+                    if self.KOBRA_MODEL_CODE == 'KS1M':
+                        # S1 Max also defines a chamber circulation fan, an external exhaust fan
+                        # and a mainboard controller fan. All three respond to objects/query but
+                        # were not exposed.
+                        objects.append("fan_generic chamber_fan")
+                        objects.append("fan_generic exhaust_fan")
+                        objects.append("controller_fan controller_fan")
+
                     return { "objects": objects }
                 return await original_request(me, web_request)
             return request

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -47,14 +47,15 @@ def _read_env_from_tools() -> dict:
     """
     try:
         # Source tools.sh and print only the vars we need
-        cmd = '. /useremain/rinkhals/.current/tools.sh && echo "$KOBRA_MODEL_ID|$KOBRA_MODEL_CODE|$KOBRA_DEVICE_ID"'
+        cmd = '. /useremain/rinkhals/.current/tools.sh && echo "$KOBRA_MODEL_ID|$KOBRA_MODEL_CODE|$KOBRA_VERSION|$KOBRA_DEVICE_ID"'
         result = subprocess.check_output(['sh', '-c', cmd], stderr=subprocess.DEVNULL)
         parts = result.decode('utf-8').strip().split('|')
-        if len(parts) == 3:
+        if len(parts) == 4:
             return {
                 'KOBRA_MODEL_ID': parts[0],
                 'KOBRA_MODEL_CODE': parts[1],
-                'KOBRA_DEVICE_ID': parts[2]
+                'KOBRA_VERSION': parts[2],
+                'KOBRA_DEVICE_ID': parts[3]
             }
     except:
         pass
@@ -87,6 +88,7 @@ class Kobra:
     # Environment
     KOBRA_MODEL_ID = None
     KOBRA_MODEL_CODE = None
+    KOBRA_VERSION = None
     KOBRA_DEVICE_ID = None
     MQTT_USERNAME = None
     MQTT_PASSWORD = None
@@ -124,6 +126,7 @@ class Kobra:
 
             self.KOBRA_MODEL_ID = environment.get('KOBRA_MODEL_ID')
             self.KOBRA_MODEL_CODE = environment.get('KOBRA_MODEL_CODE')
+            self.KOBRA_VERSION = environment.get('KOBRA_VERSION')
             self.KOBRA_DEVICE_ID = environment.get('KOBRA_DEVICE_ID')
             
             def load_tool_function(function_name):
@@ -1388,17 +1391,34 @@ class Kobra:
                         objects.append("fan_generic air_filter_fan")
                         objects.append("fan_generic box_fan")
 
-                        # The chamber heater is a first-class GoKlipper heater on the S1 family
-                        # ([chamber_temp] in the stock printer.cfg, PID controlled, max_temp 65),
-                        # and it is already reported in heaters.available_heaters. It was simply
-                        # never added to this list, so Mainsail/Fluidd never subscribed to it and
-                        # users had no chamber temperature readout or setpoint in the web UI.
-                        objects.append("chamber_temp")
+                    # Asking for the existing heaters object is safe and lets the printer tell us
+                    # whether chamber_temp exists on this exact model and firmware. Do not infer
+                    # it from a model family: KS1 2.7.2.7, for example, reports no chamber heater,
+                    # and subscribing to an absent object can panic GoKlipper.
+                    try:
+                        web_request.endpoint = 'objects/query'
+                        args = web_request.get_args()
+                        args.clear()
+                        args['objects'] = { 'heaters': ['available_heaters'] }
+                        heater_result = await original_request(me, web_request)
+                        available_heaters = heater_result.get('status', {}).get(
+                            'heaters', {}
+                        ).get('available_heaters', [])
+                        if (isinstance(available_heaters, list) and
+                                'chamber_temp' in available_heaters):
+                            objects.append("chamber_temp")
+                    except Exception as e:
+                        # Fail closed. A missing chamber tile is preferable to advertising an
+                        # unverified object that a client will immediately subscribe to.
+                        logging.warning(
+                            f'[Kobra] Could not discover available heaters: {e!r}'
+                        )
 
-                    if self.KOBRA_MODEL_CODE == 'KS1M':
-                        # S1 Max also defines a chamber circulation fan, an external exhaust fan
-                        # and a mainboard controller fan. All three respond to objects/query but
-                        # were not exposed.
+                    if (self.KOBRA_MODEL_CODE == 'KS1M' and
+                            self.KOBRA_VERSION == '2.7.1.4'):
+                        # These three fans are verified on KS1M 2.7.1.4 only. In particular,
+                        # exhaust_fan was introduced in that firmware; exposing it on older
+                        # releases risks a fatal subscription to an object GoKlipper lacks.
                         objects.append("fan_generic chamber_fan")
                         objects.append("fan_generic exhaust_fan")
                         objects.append("controller_fan controller_fan")

--- a/tests/test_kobra.py
+++ b/tests/test_kobra.py
@@ -1,8 +1,10 @@
+import copy
 import importlib.util
 import sys
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[1]
@@ -13,6 +15,7 @@ COMMON_NAME = "testsupport.moonraker.common"
 UTILS_NAME = "testsupport.moonraker.utils"
 POWER_NAME = "testsupport.moonraker.components.power"
 MACHINE_NAME = "testsupport.moonraker.components.machine"
+KLIPPY_CONNECTION_NAME = "testsupport.moonraker.components.klippy_connection"
 
 
 class DummyTask:
@@ -47,11 +50,15 @@ class DummyServer:
 
 
 class DummyWebRequest:
-    def __init__(self, endpoint: str):
-        self._endpoint = endpoint
+    def __init__(self, endpoint: str, args=None):
+        self.endpoint = endpoint
+        self._args = args or {}
 
     def get_endpoint(self):
-        return self._endpoint
+        return self.endpoint
+
+    def get_args(self):
+        return self._args
 
 
 def _ensure_package(name: str):
@@ -96,6 +103,38 @@ def _build_machine_module():
     machine_module.Machine = Machine
     sys.modules[MACHINE_NAME] = machine_module
     return machine_module
+
+
+def _build_klippy_connection_module():
+    klippy_connection_module = types.ModuleType(KLIPPY_CONNECTION_NAME)
+
+    class KlippyConnection:
+        def __init__(self, available_heaters=None, heater_error=None):
+            self.available_heaters = available_heaters or []
+            self.heater_error = heater_error
+            self.requests = []
+
+        async def request(self, web_request):
+            endpoint = web_request.get_endpoint()
+            self.requests.append((endpoint, copy.deepcopy(web_request.get_args())))
+
+            if endpoint == "gcode/help":
+                return {"TEST_MACRO": "test"}
+            if endpoint == "objects/query":
+                if self.heater_error is not None:
+                    raise self.heater_error
+                return {
+                    "status": {
+                        "heaters": {
+                            "available_heaters": self.available_heaters,
+                        }
+                    }
+                }
+            return {"original": endpoint}
+
+    klippy_connection_module.KlippyConnection = KlippyConnection
+    sys.modules[KLIPPY_CONNECTION_NAME] = klippy_connection_module
+    return klippy_connection_module
 
 
 def load_kobra_module():
@@ -191,6 +230,109 @@ class KobraMachineRebootPatchTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(scheduled, [])
         self.assertEqual(machine.original_calls, [])
+
+
+class KobraEnvironmentTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_kobra_module()
+
+    @mock.patch.object(
+        load_kobra_module().subprocess,
+        "check_output",
+        return_value=b"20029|KS1M|2.7.1.4|device-id\n",
+    )
+    def test_reads_firmware_version_from_tools(self, _check_output):
+        self.assertEqual(
+            self.module._read_env_from_tools(),
+            {
+                "KOBRA_MODEL_ID": "20029",
+                "KOBRA_MODEL_CODE": "KS1M",
+                "KOBRA_VERSION": "2.7.1.4",
+                "KOBRA_DEVICE_ID": "device-id",
+            },
+        )
+
+
+class KobraObjectsListPatchTests(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_kobra_module()
+
+    def setUp(self):
+        self.klippy_connection_module = _build_klippy_connection_module()
+        self.kobra = self.module.Kobra.__new__(self.module.Kobra)
+        self.kobra.is_goklipper_running = lambda: True
+
+    async def _objects_for(self, model, version, available_heaters=None, heater_error=None):
+        self.kobra.KOBRA_MODEL_CODE = model
+        self.kobra.KOBRA_VERSION = version
+        self.kobra.patch_objects_list()
+        connection = self.klippy_connection_module.KlippyConnection(
+            available_heaters=available_heaters,
+            heater_error=heater_error,
+        )
+        result = await connection.request(DummyWebRequest("objects/list"))
+        return result["objects"], connection.requests
+
+    async def test_ks1_without_reported_chamber_does_not_expose_it(self):
+        objects, requests = await self._objects_for(
+            "KS1",
+            "2.7.2.7",
+            available_heaters=["heater_bed", "extruder"],
+        )
+
+        self.assertNotIn("chamber_temp", objects)
+        self.assertNotIn("controller_fan controller_fan", objects)
+        self.assertEqual(
+            requests[-1],
+            (
+                "objects/query",
+                {"objects": {"heaters": ["available_heaters"]}},
+            ),
+        )
+
+    async def test_other_model_exposes_chamber_when_reported(self):
+        objects, _requests = await self._objects_for(
+            "K3",
+            "2.4.6.7",
+            available_heaters=["heater_bed", "chamber_temp", "extruder"],
+        )
+
+        self.assertIn("chamber_temp", objects)
+
+    async def test_verified_ks1m_exposes_reported_chamber_and_fans(self):
+        objects, _requests = await self._objects_for(
+            "KS1M",
+            "2.7.1.4",
+            available_heaters=["heater_bed", "chamber_temp", "extruder"],
+        )
+
+        self.assertIn("chamber_temp", objects)
+        self.assertIn("fan_generic chamber_fan", objects)
+        self.assertIn("fan_generic exhaust_fan", objects)
+        self.assertIn("controller_fan controller_fan", objects)
+
+    async def test_older_ks1m_exposes_reported_chamber_but_not_unverified_fans(self):
+        objects, _requests = await self._objects_for(
+            "KS1M",
+            "2.6.9.3",
+            available_heaters=["heater_bed", "chamber_temp", "extruder"],
+        )
+
+        self.assertIn("chamber_temp", objects)
+        self.assertNotIn("fan_generic chamber_fan", objects)
+        self.assertNotIn("fan_generic exhaust_fan", objects)
+        self.assertNotIn("controller_fan controller_fan", objects)
+
+    async def test_heater_discovery_failure_does_not_advertise_chamber(self):
+        objects, _requests = await self._objects_for(
+            "KS1M",
+            "2.7.1.4",
+            heater_error=RuntimeError("query failed"),
+        )
+
+        self.assertNotIn("chamber_temp", objects)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

On Kobra firmware that provides a chamber heater, the heater can be invisible to Mainsail and
Fluidd even though GoKlipper serves it. This discovers `chamber_temp` from GoKlipper's existing
heater capability report and adds it to the synthesised objects list only when it genuinely exists.

It also exposes the S1 Max's chamber, exhaust and mainboard fans on the one firmware where all three
have been verified: KS1M 2.7.1.4.

## Background

Because GoKlipper's `objects/list` is unusable, `patch_objects_list()` in `kobra.py` synthesises the
list that Moonraker reports to web clients. Clients subscribe only to what that list contains, so any
object missing from it is unreachable from the UI regardless of whether GoKlipper can serve it.

For `KS1` / `KS1M` the list only appended `fan_generic air_filter_fan` and `fan_generic box_fan`.

The significant omission is **`chamber_temp`**. In the stock `printer.cfg` it is a PID-controlled
heater:

```ini
[chamber_temp]
heater_pin: PB8
sensor_iio_path: /sys/bus/iio/devices/iio:device0/in_voltage1_raw
sensor_type: NTC 100K beta 3950
min_temp: -30
max_temp: 65
control: pid
```

and GoKlipper already reports it as a heater:

```json
"heaters": {
  "available_heaters": ["heater_bed", "chamber_temp", "extruder"],
  "available_sensors": ["heater_bed", "chamber_temp", "extruder"]
}
```

`M141` / `M191` also already work from the console. So the hardware, the firmware and the macros were
all in place. Only the objects list entry was missing, which meant S1 Max owners had **no chamber
temperature readout or setpoint anywhere in the web UI**.

## Changes

Capability-detected on every Kobra model and firmware:

| Object | Notes |
|---|---|
| `chamber_temp` | Added only when `heaters.available_heaters` reports it |

Added only for `KS1M` firmware `2.7.1.4`:

| Object | Pin | Notes |
|---|---|---|
| `fan_generic chamber_fan` | PB6 | Chamber circulation fan |
| `fan_generic exhaust_fan` | PB4 | External exhaust fan |
| `controller_fan controller_fan` | PB3 | Mainboard fan |

The Moonraker component now also reads `KOBRA_VERSION` from the existing `tools.sh` environment so
the fan gate follows the exact verified firmware rather than the broader model family.

## Verification

Tested on a Kobra S1 Max (`KOBRA_MODEL_CODE=KS1M`, `KOBRA_MODEL_ID=20029`, Anycubic firmware
`2.7.1.4`, Rinkhals `20260716_02`).

Before: 134 objects listed, no chamber anything. After: 138 objects.

All four return live data via `objects/query`, and also via a Fluidd-style
`printer.objects.subscribe`, which is what actually matters for the UI:

```
chamber_temp                       {"power": 0, "target": 0, "temperature": 26}
fan_generic chamber_fan            {"name": "chamber_fan", "speed": 0}
fan_generic exhaust_fan            {"name": "exhaust_fan", "speed": 0}
controller_fan controller_fan      {"rpm": 0, "speed": 0}
```

`chamber_temp` also streams live `notify_status_update` frames, so it graphs correctly rather than
sitting static:

```
update: {"chamber_temp": {"temperature": 25}}
update: {"chamber_temp": {"temperature": 26}}
```

`gklib` was not restarted; only Moonraker. No regression seen in existing panels.

Automated coverage exercises the compatibility boundaries:

- KS1 2.7.2.7 without a reported chamber does not expose `chamber_temp`.
- A chamber reported by another Kobra model is exposed without a model table.
- KS1M 2.7.1.4 exposes the reported chamber and all three verified fans.
- Older KS1M firmware can expose a reported chamber but never the three unverified fans.
- A failed or malformed heater capability query fails closed and does not advertise the chamber.

Full suite: `python -m pytest tests/ -q` - 34 passed.

## Compatibility and safety

The original patch inferred chamber support from the S1 model family and exposed all three fans on
every supported KS1M firmware. Review correctly identified that subscribing to a nonexistent object
can panic some GoKlipper versions and require a power cycle.

The revised code queries only the already-present `heaters` object for `available_heaters`. It adds
`chamber_temp` only when that response contains the exact name; query failures fail closed. This
also incorporates the field report that KS1 2.7.2.7 has no `[chamber_temp]` section and does not
report that heater.

There is no equivalent safe fan capability report. The three additional fan objects therefore stay
gated to KS1M 2.7.1.4, the exact model and firmware used for the live verification above. Older KS1M
versions and KS1 do not receive those entries.
