### PR TITLE
fix spoolman integration

### DIFF
--- a/build/4-apps/40-moonraker/get-moonraker.sh
+++ b/build/4-apps/40-moonraker/get-moonraker.sh
@@ -26,6 +26,16 @@ cp -pr "$WORK"/moonraker/*/* $MOONRAKER_DIRECTORY/moonraker
 SPOOLMAN_FILE="$MOONRAKER_DIRECTORY/moonraker/moonraker/components/spoolman.py"
 if [ -f "$SPOOLMAN_FILE" ] && ! grep -q "SPOOL_ID: Union\[int, None\]" "$SPOOLMAN_FILE"; then
 	perl -0pi -e 's/def set_active_spool\(self, spool_id: Union\[int, None\]\) -> None:\n        assert spool_id is None or isinstance\(spool_id, int\)/def set_active_spool(self, spool_id: Union[int, None] = None, SPOOL_ID: Union[int, None] = None) -> None:\n        if spool_id is None and SPOOL_ID is not None:\n            spool_id = int(str(SPOOL_ID).lstrip("="))\n        assert spool_id is None or isinstance(spool_id, int)/' "$SPOOLMAN_FILE"
+
+	# Fail loudly rather than shipping an unpatched spoolman.py. The perl
+	# substitution matches an exact two-line pattern, so a MOONRAKER_COMMIT bump
+	# or any upstream reformatting would silently match nothing and exit 0 -
+	# and the M555 SPOOL_ID handling this patch exists for would quietly
+	# regress, to be discovered by a user rather than by the build.
+	if ! grep -q "SPOOL_ID: Union\[int, None\]" "$SPOOLMAN_FILE"; then
+		echo "ERROR: spoolman.py SPOOL_ID patch did not apply - did upstream Moonraker change set_active_spool?" >&2
+		exit 1
+	fi
 fi
 
 VERSION=$(echo $MOONRAKER_COMMIT | cut -c1-7)

--- a/build/4-apps/40-moonraker/get-moonraker.sh
+++ b/build/4-apps/40-moonraker/get-moonraker.sh
@@ -21,5 +21,12 @@ mkdir -p $MOONRAKER_DIRECTORY/moonraker
 rm -rf $MOONRAKER_DIRECTORY/moonraker/*
 cp -pr "$WORK"/moonraker/*/* $MOONRAKER_DIRECTORY/moonraker
 
+# Apply Rinkhals spoolman compatibility fix directly in Moonraker source.
+# See: https://github.com/utkabobr/DuckPro-Kobra3/issues/54#issuecomment-2540040852
+SPOOLMAN_FILE="$MOONRAKER_DIRECTORY/moonraker/moonraker/components/spoolman.py"
+if [ -f "$SPOOLMAN_FILE" ] && ! grep -q "SPOOL_ID: Union\[int, None\]" "$SPOOLMAN_FILE"; then
+	perl -0pi -e 's/def set_active_spool\(self, spool_id: Union\[int, None\]\) -> None:\n        assert spool_id is None or isinstance\(spool_id, int\)/def set_active_spool(self, spool_id: Union[int, None] = None, SPOOL_ID: Union[int, None] = None) -> None:\n        if spool_id is None and SPOOL_ID is not None:\n            spool_id = int(str(SPOOL_ID).lstrip("="))\n        assert spool_id is None or isinstance(spool_id, int)/' "$SPOOLMAN_FILE"
+fi
+
 VERSION=$(echo $MOONRAKER_COMMIT | cut -c1-7)
 sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${VERSION}\"/" $MOONRAKER_DIRECTORY/app.json

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -962,7 +962,8 @@ class Kobra:
                 # unconditional int(SPOOL_ID) turned that into a TypeError.
                 if spool_id is None and SPOOL_ID is not None:
                     logging.info('[Kobra] Injected SPOOL_ID')
-                    spool_id = int(SPOOL_ID)
+                    # Strip leading = in case macro passed SPOOL_ID with syntax S=5 vs S5
+                    spool_id = int(str(SPOOL_ID).lstrip('='))
                 return original_set_active_spool(me, spool_id)
             return set_active_spool
 


### PR DESCRIPTION
## Summary

* Fixes spoolman integration not working sometimes
* go klipper passes `M555 S=5` as `=5` into SPOOL_ID. The updated function handles both cases where SPOOL_ID is either `=5` or `5`

## Why

Fixes spoolman integration so users dont have to manually patch spoolman.py as per [this](https://github.com/utkabobr/DuckPro-Kobra3/issues/54#issuecomment-2540040852)

## Changes

- Patch the `spoolman.py` that comes from moonraker source
- Strip `=` from SPOOL_ID, if `M555 S=5` is used as per [this](https://rinkhals-community.github.io/Rinkhals/guides/spoolman-support/) doc. The function will still work if it receives SPOOL_ID without `=` i.e just `5`

## Testing

How did you test this? Include printer model and firmware version if relevant.
For changes that affect hardware behaviour, manual verification on the target printer is strongly preferred.

- [ ] Existing tests in `tests/` still pass (if applicable)
- [ ] Manually tested on a real printer (model and firmware)
- [ ] Documentation updated if user-visible behaviour changed

* Ran `just app-moonraker` and verified `spoolman.py` in the moonraker source code was patched as expected
* I have tested this patch on S1 with 2.7.2.7 firmware
* Have *not* tested the full Rinkhals build though

## Related issues

Fixes # https://github.com/rinkhals-community/Rinkhals/discussions/108
Related to #

## Notes for reviewers

Anything reviewers should pay particular attention to. Risky areas, decisions you went back and forth on, open questions.
