### PR TITLE
chore(deps): bump dompurify to 3.4.13 and @sveltejs/kit to 2.70.3

### DIFF
--- a/web-portal/package-lock.json
+++ b/web-portal/package-lock.json
@@ -10,14 +10,14 @@
 			"dependencies": {
 				"@xterm/addon-fit": "^0.11.0",
 				"@xterm/xterm": "^6.0.0",
-				"dompurify": "^3.4.12",
+				"dompurify": "^3.4.13",
 				"lucide-svelte": "^1.0.1",
 				"marked": "^18.0.4",
 				"qrcode": "^1.5.4"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^3.0.10",
-				"@sveltejs/kit": "^2.69.3",
+				"@sveltejs/kit": "^2.70.3",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@tailwindcss/vite": "^4.1.18",
 				"@types/dompurify": "^3.0.5",
@@ -938,9 +938,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.69.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.3.tgz",
-			"integrity": "sha512-cphwqMRcE19/9VkrIPr5qZhQ0SptSSDfDzRUpYHu9OJDFGuYBFyJzK+KQA27wB4YG32O/yF2QjBkDmTyo0vtCw==",
+			"version": "2.70.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.3.tgz",
+			"integrity": "sha512-UDvEYuZqAMbfB/oXIoqKvbKcb7YczK5zYrzmsGV1zRJk03jntwp8dXiYoIJotxAndsKvcPFtx9H1GRSKFdSHgg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1579,9 +1579,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.12",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+			"integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"

--- a/web-portal/package.json
+++ b/web-portal/package.json
@@ -13,7 +13,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.69.3",
+		"@sveltejs/kit": "^2.70.3",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/dompurify": "^3.0.5",
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"@xterm/addon-fit": "^0.11.0",
 		"@xterm/xterm": "^6.0.0",
-		"dompurify": "^3.4.12",
+		"dompurify": "^3.4.13",
 		"lucide-svelte": "^1.0.1",
 		"marked": "^18.0.4",
 		"qrcode": "^1.5.4"


### PR DESCRIPTION
Supersedes #104 and #93, which cannot be merged as they stand.

## Why the bot PRs are stuck

Dependabot reads `.github/dependabot.yml` from the **repository default branch (`master`)**. Our config with `target-branch: develop` currently only exists on `develop`, so Dependabot still tracks `master` for these PRs even after I retargeted their base by hand. Asked to rebase, it answered:

> Looks like this PR is already up-to-date with **master**!

So both branches remain based on a `master` that predates #90 and #79. Their `package.json` edits therefore conflict with `develop` (`3.4.7 -> 3.4.13` versus develop's `3.4.12`) and with each other, since both touch adjacent lines. GitHub reports them `MERGEABLE`, but that verdict is stale - a real `git merge` conflicts.

This is self-correcting: once the release lands `dependabot.yml` on `master`, Dependabot will target `develop` properly.

## This PR

Applies both bumps directly in one commit, which also sidesteps the mutual conflict.

| package | from | to | type |
|---|---|---|---|
| dompurify | 3.4.12 | 3.4.13 | runtime (ships to printers) |
| @sveltejs/kit | 2.69.3 | 2.70.3 | dev only |

It is also **cleaner than either bot PR**: both of those branched from a lockfile predating #97 and so re-added the Tailwind wasm32-wasi tree, whereas this diff changes no licences at all.

## Verification

- Only `package.json` and `package-lock.json` change.
- No packages with install scripts added; every `resolved` URL is registry.npmjs.org.
- **Zero licence lines added or removed.**
- `npm ci && npm run build` succeeds; adapter-static writes the site.