### PR TITLE
fix(ci): web-portal build was silently skipped on PRs that changed it

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,19 +24,36 @@ jobs:
     name: Web portal builds
     runs-on: ubuntu-latest
     steps:
+      # Full history: the change detection below needs a common ancestor with the
+      # base branch, which a shallow clone does not have.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect web-portal changes
         id: changed
         run: |
+          # Fail SAFE, not open: only skip the build when we can positively prove
+          # web-portal/ is untouched. The first version of this compared against a
+          # depth-1 fetch of the base, so there was no merge base, the diff came
+          # back empty, and the build was silently skipped on PRs that did change
+          # web-portal - a check that quietly does nothing is worse than no check.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -q '^web-portal/'; then
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            echo "Could not resolve base commit, building anyway" >&2
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD -- web-portal/ || true)
+          if [ -n "$CHANGED" ]; then
+            echo "web-portal changed:"; echo "$CHANGED"
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
+            echo "no web-portal changes, skipping build"
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
The PR check added in #92 was not doing its job.

## What happened

On #113 - which bumped `dompurify` and `@sveltejs/kit`, i.e. exactly the case the check exists for - the job reported **success in 5 seconds**:

```
Detect web-portal changes: success
Run actions/setup-node@v4:  skipped
npm ci:                     skipped
npm run build:              skipped
```

`actions/checkout` clones shallow by default, and the step then fetched the base at `--depth=1`. With no common ancestor, `git diff origin/<base>...HEAD` returned nothing, so the step concluded `web-portal/` was untouched and skipped every npm step.

So since #92 landed, **no PR has actually had the frontend built**, while the check reported green. That is worse than having no check, because it reports success.

## Fix

1. `fetch-depth: 0` so a merge base exists.
2. Diff against the PR's own `base.sha` rather than a fetched ref.
3. **Fail safe**: if the base SHA cannot be resolved, build anyway. The step now only skips when it can positively demonstrate `web-portal/` is untouched, and logs the files it saw either way.

## Note

This is the same failure mode I asked #110 to fix in its `perl` patch - a step that quietly no-ops and exits 0. I wrote it here myself, so the principle stands: verify the thing happened, and treat "cannot tell" as a reason to act rather than to skip.

The green `Web portal builds` job on this PR is meaningful only if it actually runs; since this PR does not touch `web-portal/`, expect it to skip - correctly this time, and it will say so in the log. #113's dependency bumps were separately verified locally with `npm ci && npm run build`.