### PR TITLE
chore(ci): only auto-release on release tags, not every tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,9 @@ name: Auto release on tag
 on:
   push:
     tags:
-      - '*'
+      # Release tags only (YYYYMMDD_NN, optionally _test). A bare '*' meant any
+      # stray tag published a draft release with all 12 SWU assets attached.
+      - '20*'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
`auto-release.yml` triggered on `tags: ['*']`, so **any** tag pushed to the repo built and published a draft release with all 12 SWU assets. That includes GitHub's own `untagged-<hash>` placeholder tags for draft releases, two of which already exist here.

Narrowed to `'20*'`, the `YYYYMMDD_NN` release format and its `_test` variant.

Verified against every tag in the repo:

- 124 tags total
- 122 match `20*` (every real release tag)
- 2 do not: `untagged-18378938b5bb1ed1cb38`, `untagged-ab91d864bc478734410c`, both GitHub draft-release placeholders

One caveat: GitHub reads the tag filter from the workflow file **at the tagged commit**, so this takes effect for tags cut from commits containing it, starting with the next release.