### PR TITLE
chore(ci): only auto-release on release tags, not every tag (master)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,9 @@ name: Auto release on tag
 on:
   push:
     tags:
-      - '*'
+      # Release tags only (YYYYMMDD_NN, optionally _test). A bare '*' meant any
+      # stray tag published a draft release with all 12 SWU assets attached.
+      - '20*'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Same change as #123, applied to `master`.

GitHub evaluates the `push.tags` filter from the workflow file **at the tagged commit**. #123 puts this on `develop`, which covers test tags cut there, but stable releases are tagged on `master`, so master needs it too or the next release still runs with `tags: ['*']`.

Verified against every tag in the repo: 124 total, 122 match `20*` (every real release tag), and the 2 that don't are GitHub's `untagged-*` draft-release placeholders, which are exactly the strays this stops from building.